### PR TITLE
Don't install or package header files

### DIFF
--- a/debian/libopx-sdi-sys-dev.install
+++ b/debian/libopx-sdi-sys-dev.install
@@ -1,2 +1,1 @@
-usr/include/opx
 usr/lib/*/*.so

--- a/inc/Makefile.am
+++ b/inc/Makefile.am
@@ -1,4 +1,4 @@
-nobase_include_HEADERS = \
+noinst_HEADERS = \
 	opx/private/sdi_entity_internal.h \
 	opx/sdi_register_common_api.h \
 	opx/sdi_register_eeprom_api.h \


### PR DESCRIPTION
Header files of SDI plugin libraries should be private.  The public
API is defined by headers provided by opx-sdi-api.

Signed-off-by: J.T. Conklin <J.T.Conklin@Dell.Com>