### PR TITLE
opx-sdi-sys sync - 3.0.0-dev2

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -102,7 +102,7 @@ libopx_sdi_device_drivers_la_SOURCES = \
         src/drivers/sdi_fpga_pci_bus.c
         
 
-libopx_sdi_device_drivers_la_LIBADD = libopx_sdi_framework.la -lopx_common -lopx_logging -lz -lm -lpthread -lOpenIPMI -lOpenIPMIposix
+libopx_sdi_device_drivers_la_LIBADD = libopx_sdi_framework.la -lopx_common -lopx_logging -lz -lm -lpthread -lOpenIPMI -lOpenIPMIposix -lOpenIPMIpthread
 libopx_sdi_device_drivers_la_LDFLAGS = -version-info 1:1:0 -shared $(LD_HARDEN_FLAGS) 
 libopx_sdi_device_drivers_la_CFLAGS = -I$(top_srcdir)/inc/opx -I$(top_srcdir)/inc/opx/private -I$(top_srcdir)/inc/opx/private/eeprom -I$(includedir)/opx -fpic $(COMMON_HARDEN_FLAGS) $(C_HARDEN_FLAGS)
 

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.69])
-AC_INIT([opx-sdi-sys], [4.21.0], [ops-dev@lists.openswitch.net])
+AC_INIT([opx-sdi-sys], [4.22.0], [ops-dev@lists.openswitch.net])
 AM_INIT_AUTOMAKE([foreign subdir-objects])
 AC_CONFIG_SRCDIR([config.h.in])
 AC_CONFIG_HEADERS([config.h])

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,20 @@
+opx-sdi-sys (4.22.0) unstable; urgency=medium
+
+  * Update: updated media driver to support basic qsfp28-dd revisions.
+  * Update: changed err log to tracelog for sfp missing port power cfg.
+  * Bugfix: Fixed issue in reading eeprom info as part of presence poll.
+  * Bugfix: PSU fan is running at high speed then expected.
+  * Update: Restructure of media cables and their management.
+  * Update: Added logic to read entity EEPROM & cache contents when entity inserted.
+  * Update: Added logic for PPID-dependent resources.
+  * Update: Added logic for configurable fan speed RPM-percent mapping for S6K PSU.
+  * Update: Added API calls to convert between fan speed RPM and percent.
+  * Bugfix: Addressed issue in sensor key generation while adding device from driver init.
+  * Bugfux: System reboot time is optimized.
+  * Update: Using ipmi_posix_thread_setup_os_handler to handle multiple threads for bmc events and polling.
+
+ -- Dell EMC <ops-dev@lists.openswitch.net>  Mon, 9 Jul  2018 15:00:00 -0800
+
 opx-sdi-sys (4.21.0) unstable; urgency=medium
 
   * Bugfix: Fantray presence not detected properly

--- a/inc/opx/private/sdi_bmc_db.h
+++ b/inc/opx/private/sdi_bmc_db.h
@@ -77,7 +77,10 @@ void sdi_bmc_db_entity_dump (void);
  * Add sensor record to a sensor database using entity id, instance and sensor Id.
  */
 sdi_bmc_sensor_t *sdi_bmc_db_sensor_add (uint32_t id, uint32_t instance, char *name);
-
+/*
+ * Add sensor record to a sensor database using sensor id.
+ */
+sdi_bmc_sensor_t *sdi_bmc_db_sensor_add_by_name (char *name);
 /*
  * Fetch sensor record from a sensor database using entity id, instance and sensor Id.
  */

--- a/inc/opx/private/sdi_bmc_internal.h
+++ b/inc/opx/private/sdi_bmc_internal.h
@@ -41,6 +41,12 @@
 #define SDI_BMC_DEV_ATTR_DATA           "data_sdr_id"
 #define SDI_BMC_DEV_ATTR_STATUS         "status_sdr_id"
 
+#define SDI_BMC_INT_USE_ELM_OFFSET      "int_use_elm_offset"
+#define SDI_BMC_AIRFLOW_OFFSET          "airflow_offset"
+#define SDI_BMC_PSU_TYPE_OFFSET         "psu_type_offset"
+
+#define SDI_BMC_MAX_INT_USE_AREA        (256)
+#define SDI_BMC_INVALID_OFFSET          (0xFFFFFFFF)
 /*
  * BMC entity info offsets.
  */
@@ -89,6 +95,7 @@ typedef struct sdi_bmc_reading_s {
 } sdi_bmc_reading_t;
 
 typedef struct sdi_bmc_entity_info_s {
+    bool     valid;
     char     board_manufacturer[SDI_MAX_NAME_LEN]; /* Manufature name */
     char     board_product_name[SDI_MAX_NAME_LEN]; /* Product name */
     char     board_serial_number[SDI_PPID_LEN];   /* board serial number is complete PPID of fantray and partial PPID of PSU's*/
@@ -150,6 +157,9 @@ typedef struct sdi_bmc_dev_resource_info_s {
     sdi_bmc_sensor_t    *data_sdr; /** Data sensor record */
     char                status_sdr_id[SDI_MAX_NAME_LEN]; /** Status sensor Id */
     sdi_bmc_sensor_t    *status_sdr; /** Status sensor record */
+    uint32_t            int_use_elm_offset; /* Internal use area element offset */
+    uint32_t            airflow_offset; /* Airflow data offset in element data */
+    uint32_t            psu_type_offset; /* PSU type data offset in element data */
     uint32_t            fan_count;   /** Number fans present in this entity */
     uint32_t            max_fan_speed /** Max fan speed */;
     sdi_device_hdl_t    dev_hdl;  /** Device handle */
@@ -172,6 +182,12 @@ typedef struct sdi_bmc_dev_s {
     char                alias[SDI_MAX_NAME_LEN]; /** BMC device alias */
     sdi_bmc_dev_list_t  *dev_list; /** Device list */
 } sdi_bmc_dev_t;
+
+/*
+ *
+ */
+
+sdi_bmc_dev_resource_info_t * sdi_bmc_dev_get_by_data_sdr (sdi_device_hdl_t dev_hdl, char *sdr_id);
 
 /**
  * BMC FAN device registration function.

--- a/inc/opx/private/sdi_entity_internal.h
+++ b/inc/opx/private/sdi_entity_internal.h
@@ -82,6 +82,8 @@ struct sdi_entity {
     sdi_resource_hdl_t entity_info_hdl; /**entity_info handler of an entity */
     sdi_entity_info_t entity_info; /**<entity_info of an entity */
     std_dll_head *resource_list;/**<list of resources that are part of this entity*/
+    bool present;
+    bool entity_info_valid;
 }sdi_entity_t;
 
 /**

--- a/inc/opx/private/sdi_fan_internal.h
+++ b/inc/opx/private/sdi_fan_internal.h
@@ -30,17 +30,34 @@
 #ifndef __SDI_FAN_INTERNAL_H_
 #define __SDI_FAN_INTERNAL_H_
 
+#include <sys/types.h>
+#include <regex.h>
+
 #include "std_error_codes.h"
 #include "std_type_defs.h"
 #include "sdi_entity.h"
 #include "sdi_fan.h"
+
+/* One mapping entry in map, below; given RPM <=> given % */
+struct sdi_fan_speed_map_entry {
+    struct sdi_fan_speed_map_entry *next;
+    uint_t  rpm;
+    uint_t  pct;
+};
+
+/* Mapping between fan speed RPM and percent */
+struct sdi_fan_speed_ppid_map {
+    struct sdi_fan_speed_ppid_map *next;
+    regex_t ppid_pat[1]; /* Map applies for entities with PPID matching this RE */
+    struct sdi_fan_speed_map_entry *speeds;
+};
 
 /**
  * Each Fan resource provides the following callbacks.so the following api have
  * to be provided by the driver when registering a fan resource with the sdi
  * framework
  */
- typedef struct {
+typedef struct {
     /**
      * callback function for resource init
      */
@@ -48,14 +65,39 @@
     /**
      * callback function for getting the speed(in RPM) of the Fan
      */
-    t_std_error (*speed_get)(void *resource_hdl, uint_t *speed);
+    t_std_error (*speed_get)(sdi_resource_hdl_t real_resource_hdl,
+                             void *resource_hdl,
+                             uint_t *speed
+                             );
     /**
      * callback function for setting the speed for the Fan
      */
-    t_std_error (*speed_set)(void *resource_hdl, uint_t speed);
+    t_std_error (*speed_set)(sdi_resource_hdl_t real_resource_hdl,
+                             void *resource_hdl,
+                             uint_t speed
+                             );
     /**
      * callback function to get the status of the Fan
      */
     t_std_error (*status_get)(void *resource_hdl, bool *status);
+
+    /* Callback to convert fan speed RPM to percent;
+       NIL => Fall back to (rpm / max_speed) * 100 to calculate %
+     */
+    uint_t (*speed_rpm_to_pct)(sdi_resource_hdl_t real_resource_hdl,
+                               void *resource_hdl,
+                               uint_t rpm
+                               );
+
+    /* Callback to convert fan speed percent to RPM;
+       NIL => Fall back to (pct / 100) * max_speed to calculate RPM
+     */
+    uint_t (*speed_pct_to_rpm)(sdi_resource_hdl_t real_resource_hdl,
+                               void *resource_hdl,
+                               uint_t pct
+                               );
+
+    /* Fan speed RPM-to-percent map for fan; NIL => none */
+    struct sdi_fan_speed_ppid_map *speed_ppid_map;
 } fan_ctrl_t;
 #endif

--- a/inc/opx/private/sdi_media_attr.h
+++ b/inc/opx/private/sdi_media_attr.h
@@ -128,6 +128,16 @@
 /* @def Attribute used for representing 10G mode value for port led  */
 #define SDI_MEDIA_PORT_LED_10G_MODE_VALUE       "port_led_10g_mode_value"
 
+/**
+ * @def Attribute used for representing max power the port can provide in mW
+ */
+#define SDI_MEDIA_MAX_PORT_POWER_MILLIWATTS      "max_port_power_mw"
+
+#define SDI_MEDIA_DEFAULT_QSFP28_DD_MAX_PORT_POWER_MILLIWATTS     7000
+#define SDI_MEDIA_DEFAULT_QSFP28_MAX_PORT_POWER_MILLIWATTS        4500
+#define SDI_MEDIA_DEFAULT_QSFP_MAX_PORT_POWER_MILLIWATTS          3500
+#define SDI_MEDIA_DEFAULT_SFP_MAX_PORT_POWER_MILLIWATTS           2000
+
 /* @def Attribute used for representing port type SFP/SFP28/QSFP/QSFP28/DD-QSFP28 */
 #define SDI_MEDIA_PORT_TYPE                     "port_type"
 

--- a/inc/opx/private/sdi_media_internal.h
+++ b/inc/opx/private/sdi_media_internal.h
@@ -182,6 +182,14 @@ typedef struct {
     t_std_error (*media_qsa_adapter_type_get)(sdi_resource_hdl_t resource_hdl,
             sdi_qsa_adapter_type_t* qsa_adapter);
 
+    /* For obtaining the port info */
+    t_std_error (*media_port_info_get)(sdi_resource_hdl_t resource_hdl,
+            sdi_media_port_info_t* port_info);
+
+    /* For obtaining the module info */
+    t_std_error (*media_module_info_get)(sdi_resource_hdl_t resource_hdl,
+            sdi_media_module_info_t* module_info);
+
 } media_ctrl_t;
 
 #endif

--- a/inc/opx/private/sdi_pmbus_dev.h
+++ b/inc/opx/private/sdi_pmbus_dev.h
@@ -33,6 +33,7 @@
 #include "std_config_node.h"
 #include "sdi_resource_internal.h"
 #include "sdi_driver_internal.h"
+#include "sdi_fan_internal.h"
 #include "sdi_i2c.h"
 
 /**
@@ -135,6 +136,7 @@ typedef struct sdi_pmbus_dev_ {
     uint_t pec_req; /**<SMBUS PEC support requirement of the device*/
     sdi_pmbus_sensor_t *sdi_pmbus_sensors; /**<sensor definition of the device*/
     void *private_data;/**<Device private data*/
+    struct sdi_fan_speed_ppid_map *fan_speed_map; /* Fan speed RPM-to-% mapping, if any */
 }sdi_pmbus_dev_t;
 
 typedef struct sdi_pmbus_resource_hdl_ {

--- a/inc/opx/private/sdi_qsfp.h
+++ b/inc/opx/private/sdi_qsfp.h
@@ -71,7 +71,18 @@ typedef struct qsfp_device {
     qsfp_category_t  mod_category; /**<media category to distinguish between
                                      QSFP/QSFPPLUS/QSFP28/QSFPDD */
     sdi_media_speed_t  capability; /**<Front panel port or media capability */
+
+
+    sdi_media_module_info_t module_info;
+
+    sdi_media_port_info_t port_info;
+
+    uint_t eeprom_version; /* Used for QSFP28-DD EEPROM version */
 } qsfp_device_t;
+
+/* This function overrides the LP_MODE hardware pin. Use carefully */
+/* If this function is used to set power HIGH, one must also use it to set power LOW */
+t_std_error sdi_qsfp_media_force_power_mode_set(sdi_resource_hdl_t resource_hdl, bool state);
 
 /**
  * @brief Get the required module alarm status of qsfp
@@ -398,6 +409,26 @@ t_std_error sdi_qsfp_phy_serdes_control (sdi_resource_hdl_t resource_hdl, uint_t
 
 t_std_error sdi_qsfp_qsa_adapter_type_get (sdi_resource_hdl_t resource_hdl,
                                    sdi_qsa_adapter_type_t* qsa_adapter);
+
+/**
+ * @brief API to get the info of the port in which the device is connected
+ * resource_hdl[in] - Handle of the resource
+ * sdi_media_port_info_t*[out] - port info type obtained
+ * return           - t_std_error
+ */
+
+t_std_error sdi_qsfp_port_info_get (sdi_resource_hdl_t resource_hdl,
+                                 sdi_media_port_info_t* port_info);
+
+/**
+ * @brief API to get the module
+ * resource_hdl[in] - Handle of the resource
+ * sdi_media_module_info_t*[out] - module info
+ * return           - t_std_error
+ */
+
+t_std_error sdi_qsfp_module_info_get (sdi_resource_hdl_t resource_hdl,
+                                 sdi_media_module_info_t* module_info);
 
 
 #endif

--- a/inc/opx/private/sdi_qsfp_reg.h
+++ b/inc/opx/private/sdi_qsfp_reg.h
@@ -55,6 +55,7 @@ typedef enum {
     QSFP_TX_CONTROL_OFFSET          = 86,
     QSFP_RX_EXT_RATE_SELECT_OFFSET  = 87,
     QSFP_TX_EXT_RATE_SELECT_OFFSET  = 88,
+    QSFP_POWER_CLASS_CONTROL_OFFSET = 93,
     QSFP_CDR_CONTROL_OFFSET         = 98,
     QSFP_FREE_SIDE_DEV_PROP_OFFSET  = 113,
     QSFP_PAGE_SELECT_BYTE_OFFSET    = 127,
@@ -155,6 +156,29 @@ typedef enum {
     QSFP_DD_TX_CONTROL_OFFSET                    = 84,
     QSFP_DD_TX_CDR_CONTROL_OFFSET                = 90,
     QSFP_DD_RX_CDR_CONTROL_OFFSET                = 91,
+
+
+    /* QSFP28-DD Rev 2 offsets */
+    QSFP28_DD_R2_TEMPERATURE_OFFSET            = 26,
+    QSFP28_DD_R2_VOLTAGE_OFFSET                = 30,
+
+    /* QSFP28-DD Rev 3 offsets */
+    QSFP28_DD_R3_IDENTIFIER_OFFSET             = 0,
+    QSFP28_DD_R3_TEMPERATURE_OFFSET            = 14,
+    QSFP28_DD_R3_VOLTAGE_OFFSET                = 16,
+
+    QSFP28_DD_R3_VENDOR_NAME_OFFSET            = 129,
+    QSFP28_DD_R3_VENDOR_OUI_OFFSET             = 145,
+    QSFP28_DD_R3_VENDOR_PN_OFFSET              = 148,
+    QSFP28_DD_R3_VENDOR_REVISION_OFFSET        = 164,
+    QSFP28_DD_R3_VENDOR_SN_OFFSET              = 166,
+    QSFP28_DD_R3_VENDOR_DATE_OFFSET            = 182,
+
+    QSFP28_DD_R3_LENGTH_CABLE_ASSEMBLY_OFFSET  = 202,
+    QSFP28_DD_R3_CONNECTOR_OFFSET              = 203,
+
+    QSFP28_DD_EEPROM_VERSION_OFFSET            = 0x01,
+    QSFP28_DD_REV3_SPECIAL_TYPE_OFFSET         = 0x55,
 
 } qsfp_dd_reg_offset_t;
 

--- a/inc/opx/private/sdi_resource_internal.h
+++ b/inc/opx/private/sdi_resource_internal.h
@@ -44,7 +44,11 @@
 #ifndef __SDI_RESOURCE_INTERNAL_H_
 #define __SDI_RESOURCE_INTERNAL_H_
 
+#include <sys/types.h>
+#include <regex.h>
+
 #include "sdi_entity.h"
+#include "sdi_entity_internal.h"
 #include "sdi_sys_common.h"
 
 /**
@@ -60,6 +64,8 @@
  *   as defined in this mdoule be used.
  *
  */
+
+
 struct sdi_resource {
     /**
      * name : Name of the resource which is unique in the global space, and is always
@@ -84,6 +90,10 @@ struct sdi_resource {
      * ternimated.example, "BOOT_STATUS" led
      */
     char alias[SDI_MAX_NAME_LEN];
+    
+    struct sdi_entity *parent; /* Parent entity, to which this resource belongs */
+    bool entity_ppid_regexp_valid; /* Entity ppid pattern valid */
+    regex_t entity_ppid_regexp[1]; /* Resource available only if ppid of parent entity matches this pattern */
 };
 
 

--- a/inc/opx/private/sdi_sfp.h
+++ b/inc/opx/private/sdi_sfp.h
@@ -83,6 +83,8 @@ typedef struct sfp_device {
     sdi_media_led_t port_led;
     /** Front panel port or media capability */
     sdi_media_speed_t  capability;
+
+    sdi_media_port_info_t port_info;
 } sfp_device_t;
 
 /**
@@ -451,5 +453,25 @@ t_std_error sdi_sfp_phy_serdes_control (sdi_resource_hdl_t resource_hdl, uint_t 
 
 t_std_error sdi_sfp_qsa_adapter_type_get (sdi_resource_hdl_t resource_hdl,
                                    sdi_qsa_adapter_type_t* qsa_adapter);
+
+/**
+ * @brief API to get the info of the port in which the device is connected
+ * resource_hdl[in] - Handle of the resource
+ * sdi_media_port_info_t*[out] - port info type obtained
+ * return           - t_std_error
+ */
+
+t_std_error sdi_sfp_port_info_get (sdi_resource_hdl_t resource_hdl,
+                                 sdi_media_port_info_t* port_info);
+
+/**
+ * @brief API to get the module
+ * resource_hdl[in] - Handle of the resource
+ * sdi_media_module_info_t*[out] - module info
+ * return           - t_std_error
+ */
+
+t_std_error sdi_sfp_module_info_get (sdi_resource_hdl_t resource_hdl,
+                                 sdi_media_module_info_t* module_info);
 
 #endif

--- a/inc/opx/sdi_fan.h
+++ b/inc/opx/sdi_fan.h
@@ -69,6 +69,22 @@ t_std_error sdi_fan_speed_set(sdi_resource_hdl_t fan_hdl, uint_t speed);
 t_std_error sdi_fan_status_get(sdi_resource_hdl_t fan_hdl, bool *alert_on);
 
 /**
+ * @brief Convert fan speed in RPM to percent
+ * @param[in] fan_hdl - Handle to fan resource
+ * @param[in] rpm - Speed in RPM
+ * @return - Speed in percent, [0..100]
+ */
+uint_t sdi_fan_speed_rpm_to_pct(sdi_resource_hdl_t fan_hdl, uint_t rpm);
+
+/**
+ * @brief Convert fan speed in percent to RPM
+ * @param[in] fan_hdl - Handle to fan resource
+ * @param[in] pct - Speed in percent
+ * @return - Speed in RPM
+ */
+uint_t sdi_fan_speed_pct_to_rpm(sdi_resource_hdl_t fan_hdl, uint_t pct);
+
+/**
  * @}
  */
 

--- a/inc/opx/sdi_media.h
+++ b/inc/opx/sdi_media.h
@@ -94,6 +94,22 @@ extern "C" {
 
 
 /**
+ * @defgroup sdi media power info 
+ * @ingroup sdi_media_api
+ * @{
+ */
+
+/**
+ * @def SDI_MEDIA_NO_MAX_POWER_DEFINED
+ * Max power for media is undef
+ */
+#define SDI_MEDIA_NO_MAX_POWER_DEFINED -1
+/**
+ * @}
+ */
+
+
+/**
  * @defgroup sdi_media_address_page_select. SDI media device address and page select values
  * @ingroup sdi_media_api
  * @{
@@ -314,6 +330,8 @@ typedef enum {
     /* Media EEPROM page 3 */
     SDI_MEDIA_PAGE_03                      =  3,
 
+    /* Media EEPROM page 16 */
+    SDI_MEDIA_PAGE_16                      = 16,
     /* Media EEPROM default page when no page is selected */
     SDI_MEDIA_PAGE_DEFAULT                 = SDI_MEDIA_PAGE_00,
 } sdi_media_page_t;
@@ -1089,6 +1107,7 @@ typedef struct {
     bool rate_select_status;
     bool tx_control_support_status;
     bool paging_support_status;
+    bool software_controlled_power_mode_status;
 } sdi_qsfp_supported_feature_t;
 
 /**
@@ -1109,6 +1128,19 @@ typedef union {
     sdi_qsfp_supported_feature_t qsfp_features;
     sdi_sfp_supported_feature_t sfp_features;
 } sdi_media_supported_feature_t;
+
+typedef struct {
+    uint_t max_port_speed_mbps;
+    uint_t port_density;
+    int    max_port_power_mw;
+} sdi_media_port_info_t;
+
+typedef struct {
+    uint_t module_density;
+    int    eeprom_map_version;
+    bool   software_controlled_power_mode;
+    int    max_module_power_mw;
+} sdi_media_module_info_t;
 
 /**
  * @brief Get the presence status of a specific media
@@ -1527,11 +1559,13 @@ t_std_error sdi_media_ext_rate_select (sdi_resource_hdl_t resource_hdl, uint_t c
 
 t_std_error sdi_media_wavelength_set (sdi_resource_hdl_t resource_hdl, float value);
 
-/*
- * @brief Set wavelength for tunable media
- * @param[in]  - resource_hdl - handle to the front panel port
- * @param[in]  - wavelength value
+/**
+ * @brief API to get QSA adapter type
+ * resource_hdl[in] - Handle of the resource
+ * sdi_qsa_adapter_type_t*[out] - adapter type obtained
+ * return           - t_std_error
  */
+
 t_std_error sdi_media_qsa_adapter_type_get (sdi_resource_hdl_t resource_hdl,
                                    sdi_qsa_adapter_type_t* qsa_adapter);
 

--- a/src/drivers/sdi_bmc_dev.c
+++ b/src/drivers/sdi_bmc_dev.c
@@ -77,6 +77,30 @@ void sdi_dump_bmc_config_list (sdi_device_hdl_t dev_hdl)
     }
 }
 
+sdi_bmc_dev_resource_info_t * sdi_bmc_dev_get_by_data_sdr (sdi_device_hdl_t dev_hdl, char *sdr_id)
+{
+    sdi_bmc_dev_t      *bmc_dev = NULL;
+    sdi_bmc_dev_list_t *dev_list = NULL;
+    sdi_bmc_dev_resource_info_t *ret = NULL;
+    uint32_t count = 0;
+
+    do {
+        if ((sdr_id == NULL) || (dev_hdl == NULL)) break;
+        bmc_dev = (sdi_bmc_dev_t *) dev_hdl->private_data;
+        if (bmc_dev == NULL) break;
+
+        dev_list = bmc_dev->dev_list;
+        for (count = 0; count < dev_list->count; count++) {
+            if (strcmp(dev_list->data[count].data_sdr_id, sdr_id) == 0) {
+                ret = &dev_list->data[count];
+                break;
+            }
+        }
+    } while (0);
+
+    return ret;
+}
+
 /**
  * sdi_bmc_populate_dev_list will walk through device config and populates
  * device list under BMC device.
@@ -146,6 +170,27 @@ sdi_bmc_dev_list_t * sdi_bmc_populate_dev_list(std_config_node_t node)
             attr = std_config_attr_get(cur_node, SDI_DEV_ATTR_MAX_SPEED);
             STD_ASSERT(attr != NULL);
             dev_list->data[count].max_fan_speed = (uint_t) strtoul(attr, NULL, 0);
+
+            attr = std_config_attr_get(cur_node, SDI_BMC_INT_USE_ELM_OFFSET);
+            if (attr != NULL) {
+                dev_list->data[count].int_use_elm_offset = (uint_t) strtoul(attr, NULL, 0x10);
+            } else {
+                dev_list->data[count].int_use_elm_offset = SDI_BMC_INVALID_OFFSET;
+            }
+
+            attr = std_config_attr_get(cur_node, SDI_BMC_AIRFLOW_OFFSET);
+            if (attr != NULL) {
+                dev_list->data[count].airflow_offset = (uint_t) strtoul(attr, NULL, 0x10);
+            } else {
+                dev_list->data[count].airflow_offset = SDI_BMC_INVALID_OFFSET;
+            }
+
+            attr = std_config_attr_get(cur_node, SDI_BMC_PSU_TYPE_OFFSET);
+            if (attr != NULL) {
+                dev_list->data[count].psu_type_offset = (uint_t) strtoul(attr, NULL, 0x10);
+            } else {
+                dev_list->data[count].psu_type_offset = SDI_BMC_INVALID_OFFSET;
+            }
         } else {
             continue;
         }

--- a/src/drivers/sdi_bmc_fan.c
+++ b/src/drivers/sdi_bmc_fan.c
@@ -52,7 +52,7 @@ static t_std_error sdi_bmc_fan_chip_init(sdi_device_hdl_t device_hdl);
  * speed[out]       - pointer to a buffer to get the fan speed
  * Return           - STD_ERR_OK for success or error in case of failure
  */
-static t_std_error sdi_bmc_fan_speed_get(void *resource_hdl, uint_t *speed)
+static t_std_error sdi_bmc_fan_speed_get(sdi_resource_hdl_t real_resource_hdl, void *resource_hdl, uint_t *speed)
 {
     sdi_device_hdl_t chip = NULL;
     t_std_error rc = STD_ERR_OK;

--- a/src/drivers/sdi_emc2305.c
+++ b/src/drivers/sdi_emc2305.c
@@ -134,7 +134,7 @@ static const uint8_t min_drv_reg[] = { EMC2305_FAN0_MIN_DRV_REG,
 };
 
 /* Sets the speed of the fan referred by resource*/
-static t_std_error sdi_emc2305_fan_speed_set(void *resource_hdl, uint_t speed);
+static t_std_error sdi_emc2305_fan_speed_set(sdi_resource_hdl_t real_resource_hdl, void *resource_hdl, uint_t speed);
 /* This is the registration function for emc2305 driver.*/
 static t_std_error sdi_emc2305_register(std_config_node_t node, void *bus_handle,
                                         sdi_device_hdl_t* device_hdl);
@@ -273,7 +273,7 @@ static t_std_error sdi_emc2305_resource_init(void *resource_hdl, uint_t max_rpm)
         emc2305_data->emc2305_fan[fan_id].max_speed = max_rpm;
     }
 
-    rc = sdi_emc2305_fan_speed_set(resource_hdl,
+    rc = sdi_emc2305_fan_speed_set(0, resource_hdl,
                                    emc2305_data->emc2305_fan[fan_id].max_speed);
     if(rc != STD_ERR_OK) {
         SDI_DEVICE_ERRMSG_LOG("emc2305_fan_speed_set failed for fan-%d rc: %d",
@@ -304,7 +304,7 @@ static t_std_error sdi_emc2305_resource_init(void *resource_hdl, uint_t max_rpm)
  *      N     - Number of edges
  *      M     - Multiplier defined by the Range bits
  */
-static t_std_error sdi_emc2305_fan_speed_get(void *resource_hdl, uint_t *speed)
+static t_std_error sdi_emc2305_fan_speed_get(sdi_resource_hdl_t real_resource_hdl, void *resource_hdl, uint_t *speed)
 {
     uint8_t tach= 0, ltach = 0;
     uint16_t count = 0;
@@ -367,7 +367,7 @@ static uint16_t sdi_rpm_to_tach_count (emc2305_fan_data_t *fan_data, uint_t spee
  * Return           - STD_ERR_OK for success or the respective error code from
  *                    i2c API in case of failure
  */
-static t_std_error sdi_emc2305_fan_speed_set(void *resource_hdl, uint_t speed)
+static t_std_error sdi_emc2305_fan_speed_set(sdi_resource_hdl_t real_resource_hdl, void *resource_hdl, uint_t speed)
 {
     uint_t fan_id = 0;
     uint8_t setting= 0;

--- a/src/drivers/sdi_max6620.c
+++ b/src/drivers/sdi_max6620.c
@@ -76,7 +76,7 @@ typedef struct max6620_resource_hdl
 }max6620_resource_hdl_t;
 
 /* Sets the speed of the fan referred by resource*/
-static t_std_error sdi_max6620_fan_speed_set(void *resource_hdl, uint_t speed);
+static t_std_error sdi_max6620_fan_speed_set(sdi_resource_hdl_t real_resource_hdl, void *resource_hdl, uint_t speed);
 /* This is the registration function for max6620 driver.*/
 t_std_error sdi_max6620_register(std_config_node_t node, void *bus_handle,
                                  sdi_device_hdl_t* device_hdl);
@@ -429,7 +429,7 @@ static t_std_error sdi_max6620_init_fan(sdi_device_hdl_t device_hdl, uint_t fan_
     speed_percent = DRV_VOLT_TO_SPEED_PERCENT(drv_volt);
     rpm = SPEED_PERCENT_TO_RPM(max6620_data->max6620_fan[fan_id].max_speed, speed_percent);
 
-    rc = sdi_max6620_fan_speed_set(&max6620_resource, rpm);
+    rc = sdi_max6620_fan_speed_set(0, &max6620_resource, rpm);
     if(rc != STD_ERR_OK)
     {
         SDI_DEVICE_ERRMSG_LOG("max6620_fan_speed_set failed for fan- %d rc: %d\n", fan_id, rc);
@@ -511,7 +511,7 @@ static t_std_error sdi_max6620_resource_init(void *resource_hdl, uint_t max_rpm)
  * SR = Speed Range (1,2,4,8,16,32) Value in the fan_dynamic register - 06h,07h,08h,09h
  * NP = For a nominal fan it will be two.
  */
-static t_std_error sdi_max6620_fan_speed_get(void *resource_hdl, uint_t *speed)
+static t_std_error sdi_max6620_fan_speed_get(sdi_resource_hdl_t real_resource_hdl, void *resource_hdl, uint_t *speed)
 {
     uint_t tach_count = 0;
     uint_t fan_id = 0;
@@ -560,7 +560,7 @@ static t_std_error sdi_max6620_fan_speed_get(void *resource_hdl, uint_t *speed)
  * [in] speed - Speed to be set
  * Return - STD_ERR_OK for success or the respective error code from i2c API in case of failure
  */
-static t_std_error sdi_max6620_fan_speed_set(void *resource_hdl, uint_t speed)
+static t_std_error sdi_max6620_fan_speed_set(sdi_resource_hdl_t real_resource_hdl, void *resource_hdl, uint_t speed)
 {
     uint_t tgt_tach_count = 0;
     uint_t fan_id = 0;

--- a/src/drivers/sdi_qsfp_eeprom.c
+++ b/src/drivers/sdi_qsfp_eeprom.c
@@ -60,7 +60,9 @@
 /* To be removed once full qsfp28 dd rev 2 support is added */
 #define QSFP28_DD_EEPROM_VERSION_OFFSET   1
 #define QSFP28_DD_EEPROM_VERSION_2        0x20
+#define QSFP28_DD_EEPROM_VERSION_3        0x30
 #define QSFP28_DD_DATAPATH_POWERUP_OFFSET 92
+#define QSFP28_DD_DATAPATH_POWERUP_OFFSET_REV3 128 // on page 16
 #define QSFP28_DD_DATAPATH_POWERUP_VALUE  0xFF
 
 /* QSFP channel numbers */
@@ -124,6 +126,35 @@ static sdi_qsfp_reg_info_t param_reg_info[] = {
     { QSFP_FREE_SIDE_DEV_PROP_OFFSET, SDI_QSFP_BYTE_SIZE}, /* For  SDI_FREE_SIDE_DEV_PROP */
 };
 
+/* For QSFP28-DD rev 3: parameter register information strucutre. Parameters should be defined in the
+ * same order of sdi_media_param_type_t */
+   static sdi_qsfp_reg_info_t param_reg_info_qsfp28_dd_r3[] = {
+    { 0, 0 }, /* not yet implemented */
+    { 0, 0 }, /* for 0 */
+    { 0, 0 }, /* for SDI_MEDIA_MAX_CASE_TEMP */
+    { 0, 0 }, /* for SDI_MEDIA_CC_BASE */
+    { 0, 0 }, /* for SDI_MEDIA_CC_EXT */
+    { QSFP28_DD_R3_CONNECTOR_OFFSET, SDI_QSFP_BYTE_SIZE }, /* for SDI_MEDIA_CONNECTOR */
+    { 0, 0 }, /* for SDI_MEDIA_ENCODING_TYPE */
+    { 0, 0 }, /* for SDI_MEDIA_NM_BITRATE */
+    { QSFP28_DD_R3_IDENTIFIER_OFFSET, SDI_QSFP_BYTE_SIZE }, /* for SDI_MEDIA_IDENTIFIER */
+    { 0, 0 }, /* for SDI_MEDIA_EXT_IDENTIFIER */
+    { 0, 0 }, /* for SDI_MEDIA_LENGTH_SMF_KM */
+    { 0, 0 }, /* for SDI_MEDIA_LENGTH_OM1 */
+    { 0, 0 }, /* for SDI_MEDIA_LENGTH_OM2 */
+    { 0, 0 }, /* for SDI_MEDIA_LENGTH_OM3 */
+    { QSFP28_DD_R3_LENGTH_CABLE_ASSEMBLY_OFFSET, SDI_QSFP_BYTE_SIZE  }, /* for SDI_MEDIA_LENGTH_CABLE_ASSEMBLY */
+    { 0, 0}, /* for SDI_MEDIA_LENGTH_SMF, not supported on QSFP28_DD_R3 */
+    { 0, 0 }, /* for SDI_MEDIA_OPTIONS */
+    { 0, 0 }, /* for SDI_MEDIA_ENHANCED_OPTIONS */
+    { 0, 0 }, /* for SDI_MEDIA_DIAG_MON_TYPE */
+    { 0, 0 }, /* for SDI_MEDIA_DEVICE_TECH */
+    { 0, 0 }, /* for SDI_MEDIA_MAX_BITRATE, not supported on QSFP28_DD_R3 */
+    { 0, 0 }, /* for SDI_MEDIA_MIN_BITRATE, not supported on QSFP28_DD_R3 */
+    { 0, 0 }, /* for SDI_MEDIA_EXT_COMPLIANCE_CODE, not supported on QSFP28_DD_R3 */
+    { 0, 0 }, /* For  SDI_FREE_SIDE_DEV_PROP */
+};
+
 /* vendor register information structure. Parameters in this structure should be
  * defined in the same order of sdi_media_vendor_info_type_t */
 static sdi_qsfp_reg_info_t vendor_reg_info[] = {
@@ -135,6 +166,19 @@ static sdi_qsfp_reg_info_t vendor_reg_info[] = {
     { QSFP_VENDOR_REVISION_OFFSET, SDI_MEDIA_MAX_VENDOR_REVISION_LEN, true }, /* for SDI_MEDIA_VENDOR_REVISION */
     { QSFP_VENDOR_PN_OFFSET, SDI_MEDIA_MAX_VENDOR_PART_NUMBER_LEN, true } /* Repeated because field not applicable in QSFP*/
 };
+
+/* vendor register information structure. Parameters in this structure should be
+ * defined in the same order of sdi_media_vendor_info_type_t */
+static sdi_qsfp_reg_info_t vendor_reg_info_qsfp28_dd_r3[] = {
+    { QSFP28_DD_R3_VENDOR_NAME_OFFSET, SDI_MEDIA_MAX_VENDOR_NAME_LEN, true }, /* for SDI_MEDIA_VENDOR_NAME */
+    { QSFP28_DD_R3_VENDOR_OUI_OFFSET, SDI_MEDIA_MAX_VENDOR_OUI_LEN, false }, /* for SDI_MEDIA_VENDOR_OUI */
+    { QSFP28_DD_R3_VENDOR_SN_OFFSET, SDI_MEDIA_MAX_VENDOR_SERIAL_NUMBER_LEN, true }, /* for SDI_MEDIA_VENDOR_SN */
+    { QSFP28_DD_R3_VENDOR_DATE_OFFSET, SDI_MEDIA_MAX_VENDOR_DATE_LEN, true }, /* for SDI_MEDIA_VENDOR_DATE */
+    { QSFP28_DD_R3_VENDOR_PN_OFFSET, SDI_MEDIA_MAX_VENDOR_PART_NUMBER_LEN, true }, /* for SDI_MEDIA_VENDOR_PN */
+    { QSFP28_DD_R3_VENDOR_REVISION_OFFSET, SDI_MEDIA_MAX_VENDOR_REVISION_LEN, true }, /* for SDI_MEDIA_VENDOR_REVISION */
+    { QSFP28_DD_R3_VENDOR_PN_OFFSET, SDI_MEDIA_MAX_VENDOR_PART_NUMBER_LEN, true } /* Repeated because field not applicable in QSFP*/
+};
+
 
 /* threshold value register information structure. Parameters in this structure
  * should be defined in the same order of sdi_media_threshold_type_t */
@@ -407,6 +451,201 @@ static inline t_std_error sdi_is_rate_select_supported(sdi_device_hdl_t qsfp_dev
 
     return rc;
 }
+
+static inline t_std_error sdi_is_software_controlled_power_mode_supported (
+                            sdi_device_hdl_t qsfp_device, bool *support_status)
+{
+    t_std_error rc = STD_ERR_OK;
+    uint8_t buf = 0;
+    bool paging_support = true;
+
+    STD_ASSERT(qsfp_device != NULL);
+    STD_ASSERT(support_status != NULL);
+
+    *support_status = false;
+
+    if (sdi_is_paging_supported(qsfp_device, &paging_support) != STD_ERR_OK){
+            SDI_DEVICE_ERRMSG_LOG("Unable to check for paging support on %s",
+                    qsfp_device->alias);
+    } else if (paging_support) {
+        rc = sdi_qsfp_page_select(qsfp_device, SDI_MEDIA_PAGE_DEFAULT);
+        if(rc != STD_ERR_OK) {
+            SDI_DEVICE_ERRMSG_LOG("page 0 selection is failed for %s",
+                        qsfp_device->alias);
+        }
+    }
+
+    rc = sdi_smbus_read_byte(qsfp_device->bus_hdl, qsfp_device->addr.i2c_addr,
+                             QSFP_EXT_IDENTIFIER_OFFSET, &buf, SDI_I2C_FLAG_NONE);
+    if (rc != STD_ERR_OK){
+        SDI_DEVICE_ERRMSG_LOG("Soft power mode check: qsfp smbus read failed at addr : %d rc : %d",
+                              qsfp_device->addr, rc);
+        return rc;
+    }
+
+    if ( buf & 0x03 ) {
+        *support_status = true;
+    } else {
+        *support_status = false;
+    }
+
+    return rc;
+}
+
+
+t_std_error sdi_qsfp_media_max_power_get (sdi_resource_hdl_t resource_hdl, int *pwr_milliwatts, bool* soft_ctrl)
+{
+    sdi_device_hdl_t qsfp_device = NULL;
+    qsfp_device_t *qsfp_priv_data = NULL;
+    uint8_t buf = 0;
+    t_std_error rc = STD_ERR_OK;
+
+
+    STD_ASSERT(resource_hdl != NULL);
+    qsfp_device = (sdi_device_hdl_t)resource_hdl;
+    qsfp_priv_data = (qsfp_device_t *)qsfp_device->private_data;
+    STD_ASSERT(qsfp_priv_data != NULL);
+    *soft_ctrl = false;
+    *pwr_milliwatts = SDI_MEDIA_NO_MAX_POWER_DEFINED;
+
+    if (qsfp_priv_data->mod_type == QSFP_QSA_ADAPTER) {
+        return SDI_ERRCODE(ENOTSUP);
+    }
+
+    if ((rc = sdi_qsfp_module_select(qsfp_device)) != STD_ERR_OK) {
+        SDI_DEVICE_ERRMSG_LOG("QSFP module selection failed when attempting max power get for %s",
+             qsfp_device->alias);
+        sdi_qsfp_module_deselect(qsfp_priv_data);
+        return rc;
+    }
+
+    do {
+        std_usleep(MILLI_TO_MICRO(qsfp_priv_data->delay));
+
+        rc = sdi_smbus_read_byte(qsfp_device->bus_hdl, qsfp_device->addr.i2c_addr,
+                                QSFP_EXT_IDENTIFIER_OFFSET, &buf, SDI_I2C_FLAG_NONE);
+
+        if(rc != STD_ERR_OK) {
+            SDI_DEVICE_ERRMSG_LOG("Unable to get max power info for media on %s",
+                 qsfp_device->alias);
+            return rc;
+        }
+
+        /* Check the upper 2 bits first: for legacy QSFP(28) */
+        switch ((buf & 0xC0) >> 6) {
+            case 0:
+                *pwr_milliwatts = 1500;
+                break;
+            case 1:
+                *pwr_milliwatts = 2000;
+                break;
+            case 2:
+                *pwr_milliwatts = 2500;
+                break;
+            case 3:
+                *pwr_milliwatts = 3500;
+                break;
+        }
+
+        /* If lower 2 bits are set, they override the upper 2 bit power value */
+        switch ((buf & 0x03)) {
+            case 0:
+                /* use upper two bits defined previously */
+                break;
+            case 1:
+                *soft_ctrl = true;
+                *pwr_milliwatts = 4000;
+                break;
+            case 2:
+                *soft_ctrl = true;
+                *pwr_milliwatts = 4500;
+                break;
+            case 3:
+                *soft_ctrl = true;
+                *pwr_milliwatts = 5000;
+                break;
+        }
+
+    } while(0);
+
+    sdi_qsfp_module_deselect(qsfp_priv_data);
+    return rc;
+}
+
+
+/* This function overrides the LP_MODE hardware pin. Use carefully */
+/* If this function is used to set power HIGH, one must also use it to set power LOW */
+t_std_error sdi_qsfp_media_force_power_mode_set(sdi_resource_hdl_t resource_hdl, bool state)
+{
+    sdi_device_hdl_t qsfp_device = NULL;
+    qsfp_device_t *qsfp_priv_data = NULL;
+    uint8_t buf = 0;
+    bool feature_sup, power_set_bit, hp_class_enable_bit, lp_mode_pin_override_bit;
+    t_std_error rc = STD_ERR_OK;
+
+
+    power_set_bit = !state; /* Power set bit is active low. This sets the value when power override bit is used */
+    hp_class_enable_bit = state;
+    lp_mode_pin_override_bit = true;  /* Always override the hw pin*/
+
+    STD_ASSERT(resource_hdl != NULL);
+    qsfp_device = (sdi_device_hdl_t)resource_hdl;
+    qsfp_priv_data = (qsfp_device_t *)qsfp_device->private_data;
+    STD_ASSERT(qsfp_priv_data != NULL);
+
+    if (qsfp_priv_data->mod_type == QSFP_QSA_ADAPTER) {
+        return SDI_ERRCODE(ENOTSUP);
+    }
+
+    if ((rc = sdi_qsfp_module_select(qsfp_device)) != STD_ERR_OK) {
+        SDI_DEVICE_ERRMSG_LOG("QSFP module selection failed when attempting mode class set for %s",
+             qsfp_device->alias);
+        sdi_qsfp_module_deselect(qsfp_priv_data);
+        return rc;
+    }
+
+    do {
+        std_usleep(MILLI_TO_MICRO(qsfp_priv_data->delay));
+
+        rc = sdi_is_software_controlled_power_mode_supported(qsfp_device, &feature_sup);
+
+        if(rc != STD_ERR_OK) {
+            SDI_DEVICE_ERRMSG_LOG("Unable to get soft control power info for media on %s; rc %u",
+                 qsfp_device->alias, rc);
+            break;
+        } else if (!feature_sup){
+            rc = SDI_ERRCODE(ENOTSUP);
+            break;
+        }
+
+        rc = sdi_smbus_read_byte(qsfp_device->bus_hdl, qsfp_device->addr.i2c_addr,
+                             QSFP_POWER_CLASS_CONTROL_OFFSET, &buf, SDI_I2C_FLAG_NONE);
+        if(rc != STD_ERR_OK) {
+            SDI_DEVICE_ERRMSG_LOG("Unable to read EEPROM to get power class state for media on %s;, rc %u",
+                 qsfp_device->alias, rc);
+            break;
+        }
+
+        hp_class_enable_bit ? STD_BIT_SET(buf, 2) : STD_BIT_CLEAR(buf, 2);
+        power_set_bit ? STD_BIT_SET(buf, 1) : STD_BIT_CLEAR(buf, 1);
+        lp_mode_pin_override_bit ? STD_BIT_SET(buf, 0) : STD_BIT_CLEAR(buf, 0);
+
+        std_usleep(MILLI_TO_MICRO(qsfp_priv_data->delay));
+        rc = sdi_smbus_write_byte(qsfp_device->bus_hdl, qsfp_device->addr.i2c_addr,
+                             QSFP_POWER_CLASS_CONTROL_OFFSET, buf, SDI_I2C_FLAG_NONE);
+        if(rc != STD_ERR_OK) {
+            SDI_DEVICE_ERRMSG_LOG("Unable to write EEPROM to set power class state for media on %s;, rc %u",
+                 qsfp_device->alias, rc);
+            break;
+        }
+    } while (0);
+
+        sdi_qsfp_module_deselect(qsfp_priv_data);
+        return rc;
+}
+
+
+
 
 /* Internally measured Module temperature are represented as a
  * 16-bit signed twos complement value in increments of 1/256
@@ -1282,8 +1521,13 @@ t_std_error sdi_qsfp_parameter_get(sdi_resource_hdl_t resource_hdl,
                                      param, value);
     }
 
-    offset = param_reg_info[param].offset;
-    size =  param_reg_info[param].size;
+    if (qsfp_priv_data->eeprom_version >= QSFP28_DD_EEPROM_VERSION_3) {
+        offset = param_reg_info_qsfp28_dd_r3[param].offset;
+        size = param_reg_info_qsfp28_dd_r3[param].size;
+    } else {
+        offset = param_reg_info[param].offset;
+        size =  param_reg_info[param].size;
+    }
 
     if( (offset == 0) && (size == 0) ) {
 
@@ -1406,9 +1650,15 @@ t_std_error sdi_qsfp_vendor_info_get(sdi_resource_hdl_t resource_hdl,
     do {
         std_usleep(MILLI_TO_MICRO(qsfp_priv_data->delay));
 
-        offset = vendor_reg_info[vendor_info_type].offset;
-        data_len = vendor_reg_info[vendor_info_type].size;
-        printable = vendor_reg_info[vendor_info_type].printable;
+        if (qsfp_priv_data->eeprom_version >= QSFP28_DD_EEPROM_VERSION_3) {
+            offset = vendor_reg_info_qsfp28_dd_r3[vendor_info_type].offset;
+            data_len = vendor_reg_info_qsfp28_dd_r3[vendor_info_type].size;
+            printable = vendor_reg_info_qsfp28_dd_r3[vendor_info_type].printable;
+        } else {
+            offset = vendor_reg_info[vendor_info_type].offset;
+            data_len = vendor_reg_info[vendor_info_type].size;
+            printable = vendor_reg_info[vendor_info_type].printable;
+        }
 
         /* Input buffer size should be greater than or equal to data len*/
         STD_ASSERT(size >= data_len);
@@ -1646,6 +1896,8 @@ t_std_error sdi_qsfp_module_monitor_get (sdi_resource_hdl_t resource_hdl,
     sdi_device_hdl_t qsfp_device = NULL;
     qsfp_device_t *qsfp_priv_data = NULL;
     t_std_error rc = STD_ERR_OK;
+    int temp_offset = QSFP_DD_TEMPERATURE_OFFSET;
+    int volt_offset = QSFP_DD_VOLTAGE_OFFSET;
     uint8_t temp_buf[2] = { 0 };
     uint8_t volt_buf[2] = { 0 };
 
@@ -1655,6 +1907,17 @@ t_std_error sdi_qsfp_module_monitor_get (sdi_resource_hdl_t resource_hdl,
     qsfp_device = (sdi_device_hdl_t)resource_hdl;
     qsfp_priv_data = (qsfp_device_t *)qsfp_device->private_data;
     STD_ASSERT(qsfp_priv_data != NULL);
+
+    if (qsfp_priv_data->eeprom_version >= QSFP28_DD_EEPROM_VERSION_3 ){
+        temp_offset = QSFP28_DD_R3_TEMPERATURE_OFFSET;
+        volt_offset = QSFP28_DD_R3_VOLTAGE_OFFSET;
+    } else if (qsfp_priv_data->eeprom_version < QSFP28_DD_EEPROM_VERSION_2) {
+        temp_offset = QSFP_TEMPERATURE_OFFSET;
+        volt_offset = QSFP_DD_VOLTAGE_OFFSET;
+    } else {
+        temp_offset = QSFP28_DD_R2_TEMPERATURE_OFFSET;
+        volt_offset = QSFP28_DD_R2_VOLTAGE_OFFSET;
+    }
 
     if (qsfp_priv_data->mod_type == QSFP_QSA_ADAPTER) {
         return sdi_sfp_module_monitor_get(qsfp_priv_data->sfp_device,
@@ -1673,7 +1936,7 @@ t_std_error sdi_qsfp_module_monitor_get (sdi_resource_hdl_t resource_hdl,
         {
             case SDI_MEDIA_TEMP:
                 rc = sdi_smbus_read_word(qsfp_device->bus_hdl, qsfp_device->addr.i2c_addr,
-                        QSFP_TEMPERATURE_OFFSET, (uint16_t *)temp_buf,
+                        temp_offset, (uint16_t *)temp_buf,
                         SDI_I2C_FLAG_NONE);
                 if (rc != STD_ERR_OK){
                     SDI_DEVICE_ERRMSG_LOG("qsfp smbus read failed at addr : %d ",
@@ -1683,7 +1946,7 @@ t_std_error sdi_qsfp_module_monitor_get (sdi_resource_hdl_t resource_hdl,
 
             case SDI_MEDIA_VOLT:
                 rc = sdi_smbus_read_word(qsfp_device->bus_hdl,
-                        qsfp_device->addr.i2c_addr, QSFP_VOLTAGE_OFFSET,
+                        qsfp_device->addr.i2c_addr, volt_offset,
                         (uint16_t *)volt_buf, SDI_I2C_FLAG_NONE);
                 if (rc != STD_ERR_OK){
                     SDI_DEVICE_ERRMSG_LOG("qsfp smbus read failed at addr : %d ",
@@ -1914,6 +2177,13 @@ t_std_error sdi_qsfp_feature_support_status_get (sdi_resource_hdl_t resource_hdl
         if (rc != STD_ERR_OK){
             break;
         }
+
+        rc = sdi_is_software_controlled_power_mode_supported(qsfp_device,
+                        &feature_support->qsfp_features.software_controlled_power_mode_status);
+        if (rc != STD_ERR_OK){
+            break;
+        }
+
     }while(0);
 
     sdi_qsfp_module_deselect(qsfp_priv_data);
@@ -2430,6 +2700,10 @@ t_std_error sdi_qsfp_module_init (sdi_resource_hdl_t resource_hdl, bool pres)
             if (identifier == 0x18) {
 
                 uint8_t eeprom_version = 0;
+                uint8_t datapath_state = 0;
+                uint8_t offset = QSFP28_DD_DATAPATH_POWERUP_OFFSET;
+                uint8_t page   = SDI_MEDIA_PAGE_DEFAULT;
+
                 rc = sdi_smbus_read_byte(qsfp_device->bus_hdl, qsfp_device->addr.i2c_addr,
                     QSFP28_DD_EEPROM_VERSION_OFFSET, &eeprom_version, SDI_I2C_FLAG_NONE);
                 if (rc != STD_ERR_OK) {
@@ -2437,17 +2711,37 @@ t_std_error sdi_qsfp_module_init (sdi_resource_hdl_t resource_hdl, bool pres)
                     qsfp_device->alias, rc);
                 }
 
-                if (eeprom_version == QSFP28_DD_EEPROM_VERSION_2) {
-                    SDI_DEVICE_TRACEMSG_LOG("Found media with rev 0.2 QSFP28-DD eeprom on %s",
-                        qsfp_device->alias);
+                qsfp_priv_data->eeprom_version = eeprom_version;
+                if (eeprom_version == QSFP28_DD_EEPROM_VERSION_3){
+                    offset = QSFP28_DD_DATAPATH_POWERUP_OFFSET_REV3;
+                    page = SDI_MEDIA_PAGE_16;
+                }
+
+                rc = sdi_smbus_read_byte(qsfp_device->bus_hdl, qsfp_device->addr.i2c_addr,
+                    QSFP28_DD_EEPROM_VERSION_OFFSET, &eeprom_version, SDI_I2C_FLAG_NONE);
+                if (rc != STD_ERR_OK) {
+                    SDI_DEVICE_ERRMSG_LOG("Unable to read QSFP28-DD %s eeprom version. rc: %d ",
+                    qsfp_device->alias, rc);
+                }
+
+                if (eeprom_version >= QSFP28_DD_EEPROM_VERSION_2) {
+                    SDI_DEVICE_TRACEMSG_LOG("Found media with rev %x QSFP28-DD eeprom on %s",
+                        eeprom_version, qsfp_device->alias);
 
                     std_usleep(MILLI_TO_MICRO(qsfp_priv_data->delay));
 
                     SDI_DEVICE_TRACEMSG_LOG("Attempting to powerup datapath on %s",
                         qsfp_device->alias);
 
+                    if (STD_ERR_OK != sdi_qsfp_page_select(qsfp_device, page)){
+                        SDI_DEVICE_TRACEMSG_LOG("Page select failed for module %s",
+                                       " when attempting datapath powerup", qsfp_device->alias);
+                    }
+
+                    std_usleep(MILLI_TO_MICRO(qsfp_priv_data->delay));
+
                     rc = sdi_smbus_write_byte(qsfp_device->bus_hdl, qsfp_device->addr.i2c_addr,
-                              QSFP28_DD_DATAPATH_POWERUP_OFFSET, QSFP28_DD_DATAPATH_POWERUP_VALUE, SDI_I2C_FLAG_NONE);
+                              offset, QSFP28_DD_DATAPATH_POWERUP_VALUE, SDI_I2C_FLAG_NONE);
                     if (rc != STD_ERR_OK) {
                         SDI_DEVICE_ERRMSG_LOG("Unable to write datapath powerup byte to QSFP28-DD %s eeprom version. rc: %d ",
                             qsfp_device->alias, rc);
@@ -2455,16 +2749,33 @@ t_std_error sdi_qsfp_module_init (sdi_resource_hdl_t resource_hdl, bool pres)
                     std_usleep(MILLI_TO_MICRO(qsfp_priv_data->delay));
 
                     rc = sdi_smbus_read_byte(qsfp_device->bus_hdl, qsfp_device->addr.i2c_addr,
-                        QSFP28_DD_DATAPATH_POWERUP_OFFSET, &eeprom_version, SDI_I2C_FLAG_NONE);
+                        offset, &datapath_state, SDI_I2C_FLAG_NONE);
                     if (rc != STD_ERR_OK) {
                         SDI_DEVICE_ERRMSG_LOG("Unable to read QSFP28-DD %s datapath powerup byte. rc: %d ",
                             qsfp_device->alias, rc);
                     }
-                    if ((eeprom_version != QSFP28_DD_DATAPATH_POWERUP_VALUE) | (rc != STD_ERR_OK)) {
+                    if ((datapath_state != QSFP28_DD_DATAPATH_POWERUP_VALUE) | (rc != STD_ERR_OK)) {
                         SDI_DEVICE_ERRMSG_LOG("Datapath powerup failed. Read back %u,  error %u",
-                            qsfp_device->alias, eeprom_version, rc);
+                            qsfp_device->alias, datapath_state, rc);
+                    }
+                    std_usleep(MILLI_TO_MICRO(qsfp_priv_data->delay));
+                    if (STD_ERR_OK != sdi_qsfp_page_select(qsfp_device, SDI_MEDIA_PAGE_DEFAULT)){
+                        SDI_DEVICE_TRACEMSG_LOG("Page select failed for module %s when resetting page to default"
+                                             , qsfp_device->alias);
                     }
                 }
+            } else { /* QSFP+/QSFP28. Will handle QSFP28-DD in future */
+                sdi_qsfp_module_deselect(qsfp_priv_data);
+                if (sdi_qsfp_media_max_power_get(resource_hdl, &(qsfp_priv_data->module_info.max_module_power_mw),
+                        &(qsfp_priv_data->module_info.software_controlled_power_mode)) != STD_ERR_OK) {
+                    SDI_DEVICE_ERRMSG_LOG("Unable to get media max power for module %s", qsfp_device->alias);
+                    qsfp_priv_data->module_info.max_module_power_mw = SDI_MEDIA_NO_MAX_POWER_DEFINED;
+                    qsfp_priv_data->module_info.software_controlled_power_mode =  false;
+                } else if (qsfp_priv_data->module_info.software_controlled_power_mode) {
+                    sdi_qsfp_media_force_power_mode_set(resource_hdl, false);
+                    /* Put all in low power mode first */
+                }
+                return rc;
             }
         }
 
@@ -2688,7 +2999,7 @@ t_std_error sdi_qsfp_qsa_adapter_type_get (sdi_resource_hdl_t resource_hdl,
 
     rc = sdi_pin_group_acquire_bus(qsfp_priv_data->mod_reset_hdl);
     if (rc != STD_ERR_OK){
-        SDI_DEVICE_ERRMSG_LOG("COuld not acquire bus when attempting module reset for QSA detection");
+        SDI_DEVICE_ERRMSG_LOG("Could not acquire bus when attempting module reset for QSA detection");
         *qsa_adapter = SDI_QSA_ADAPTER_UNKNOWN;
         sdi_pin_group_release_bus(qsfp_priv_data->mod_reset_hdl);
         return rc;

--- a/src/drivers/sdi_sf_fan.c
+++ b/src/drivers/sdi_sf_fan.c
@@ -83,7 +83,7 @@ static t_std_error sdi_sf_fan_chip_init(sdi_device_hdl_t device_hdl);
  * speed[out]       - pointer to a buffer to get the fan speed
  * Return           - STD_ERR_OK for success or error in case of failure
  */
-static t_std_error sdi_sf_fan_speed_get(void *resource_hdl, uint_t *speed)
+static t_std_error sdi_sf_fan_speed_get(void *real_resource_hdl, void *resource_hdl, uint_t *speed)
 {
     uint8_t low_byte = 0, high_byte = 0;
     sdi_device_hdl_t chip = NULL;

--- a/src/drivers/sdi_sfp.c
+++ b/src/drivers/sdi_sfp.c
@@ -162,6 +162,18 @@ t_std_error sdi_sfp_led_set (sdi_resource_hdl_t resource_hdl, uint_t channel,
     return rc;
 }
 
+/* Not yet implemented */
+t_std_error sdi_sfp_module_info_get (sdi_resource_hdl_t resource_hdl,
+                                 sdi_media_module_info_t* module_info)
+{
+    return STD_ERR_OK;
+}
+t_std_error sdi_sfp_port_info_get (sdi_resource_hdl_t resource_hdl,
+                                 sdi_media_port_info_t* port_info)
+{
+   return STD_ERR_OK;
+}
+
 /* Callback handlers for SFP */
 static media_ctrl_t sfp_media = {
     .presence_get = sdi_sfp_presence_get,
@@ -198,7 +210,10 @@ static media_ctrl_t sfp_media = {
     .media_phy_power_down_enable = sdi_sfp_phy_power_down_enable,
     .ext_rate_select = NULL, /* Ext rate select is not supported on SFP */
     .media_phy_serdes_control = sdi_sfp_phy_serdes_control,
-    .media_qsa_adapter_type_get = sdi_sfp_qsa_adapter_type_get
+    .media_qsa_adapter_type_get = sdi_sfp_qsa_adapter_type_get,
+    .media_port_info_get = sdi_sfp_port_info_get,
+    .media_module_info_get = sdi_sfp_module_info_get
+
 };
 
 /*
@@ -368,6 +383,19 @@ static t_std_error sdi_sfp_register (std_config_node_t node, void *bus_handle,
         STD_ASSERT(led_node_attr != NULL);
         sfp_data->port_led.led_10g_mode_value = strtoul(led_node_attr, NULL, 16);
     }
+
+    node_attr = std_config_attr_get(node, SDI_MEDIA_MAX_PORT_POWER_MILLIWATTS);
+
+    if (node_attr == NULL){
+        sfp_data->port_info.max_port_power_mw = SDI_MEDIA_DEFAULT_SFP_MAX_PORT_POWER_MILLIWATTS;
+
+        SDI_DEVICE_TRACEMSG_LOG("Could not find max port power in config file for  %s"
+            "Defaulting to %u mW max port power", dev_hdl->alias,
+                 sfp_data->port_info.max_port_power_mw);
+    } else {
+        sfp_data->port_info.max_port_power_mw = strtoul(node_attr, NULL, 0);
+    }
+
 
     dev_hdl->private_data = (void *)sfp_data;
 

--- a/src/hwcore/sdi_entity_info.c
+++ b/src/hwcore/sdi_entity_info.c
@@ -24,12 +24,12 @@
  *         Currently entity_info providing support for read operations.
 ***************************************************************************************/
 
-#include "sdi_resource_internal.h"
-#include "sdi_sys_common.h"
-#include "std_assert.h"
-#include "sdi_entity_info_internal.h"
 #include <string.h>
 
+#include "private/sdi_resource_internal.h"
+#include "sdi_sys_common.h"
+#include "std_assert.h"
+#include "private/sdi_entity_info_internal.h"
 
 /**
  * brief - Read the entity info.
@@ -42,24 +42,10 @@
 t_std_error sdi_entity_info_read(sdi_resource_hdl_t resource_hdl,
                                  sdi_entity_info_t *entity_info)
 {
-    t_std_error rc = STD_ERR_OK;
-    sdi_resource_priv_hdl_t entity_info_hdl = (sdi_resource_priv_hdl_t)resource_hdl;
+    sdi_entity_priv_hdl_t entity_priv_hdl = ((sdi_resource_priv_hdl_t) resource_hdl)->parent;
+    if (!entity_priv_hdl->entity_info_valid)  return (SDI_ERRCODE(ENODATA));
 
-    /* Validate arguments */
-    STD_ASSERT(entity_info != NULL);
-    STD_ASSERT(entity_info_hdl != NULL);
-
-    if(sdi_resource_type_get(resource_hdl) != SDI_RESOURCE_ENTITY_INFO) {
-        return(SDI_ERRCODE(EPERM));
-    }
-
-    memset(entity_info, 0, sizeof(sdi_entity_info_t));
-    rc = ((entity_info_t *)entity_info_hdl->callback_fns)->entity_info_data_get(
-                           entity_info_hdl->callback_hdl, entity_info);
-    if(rc != STD_ERR_OK) {
-        SDI_ERRMSG_LOG("Failed to get the entity content of %s ",
-                       entity_info_hdl->name);
-    }
-
-    return rc;
+    memcpy(entity_info, &entity_priv_hdl->entity_info, sizeof(*entity_info));
+    
+    return (STD_ERR_OK);
 }

--- a/src/vmcore/sdi_vm_fan.c
+++ b/src/vmcore/sdi_vm_fan.c
@@ -88,3 +88,55 @@ t_std_error sdi_fan_status_get(sdi_resource_hdl_t fan_hdl, bool *alert_on)
     *alert_on = (bool)db_value;
     return STD_ERR_OK;
 }
+
+/* Convert fan speed RPM to percent */
+
+uint_t sdi_fan_speed_rpm_to_pct(sdi_resource_hdl_t fan_hdl, uint_t rpm)
+{
+    t_std_error rc;
+    sdi_resource_hdl_t info_hdl;
+    uint_t max_speed;
+
+    /* Get the associated info handle for the fan */
+    rc = sdi_db_resource_get_associated_info(sdi_get_db_handle(), fan_hdl,
+                                             SDI_RESOURCE_FAN, &info_hdl);
+    if (rc != STD_ERR_OK) {
+        return rc;
+    }
+
+    /* Use the info handle to lookup the maximum speed of the fan */
+    rc = sdi_db_int_field_get(sdi_get_db_handle(), info_hdl,
+                              TABLE_INFO, INFO_FAN_MAX_SPEED,
+                              (int *)&max_speed);
+    if (rc != STD_ERR_OK) {
+        return rc;
+    }
+    
+    return (max_speed == 0 ? 100 : (100 * rpm) / max_speed);
+}
+
+/* Convert fan speed percent to RPM */
+
+uint_t sdi_fan_speed_pct_to_rpm(sdi_resource_hdl_t fan_hdl, uint_t pct)
+{
+    t_std_error rc;
+    sdi_resource_hdl_t info_hdl;
+    uint_t max_speed;
+
+    /* Get the associated info handle for the fan */
+    rc = sdi_db_resource_get_associated_info(sdi_get_db_handle(), fan_hdl,
+                                             SDI_RESOURCE_FAN, &info_hdl);
+    if (rc != STD_ERR_OK) {
+        return rc;
+    }
+
+    /* Use the info handle to lookup the maximum speed of the fan */
+    rc = sdi_db_int_field_get(sdi_get_db_handle(), info_hdl,
+                              TABLE_INFO, INFO_FAN_MAX_SPEED,
+                              (int *)&max_speed);
+    if (rc != STD_ERR_OK) {
+        return rc;
+    }
+    
+    return (max_speed == 0 ? max_speed : (pct * max_speed) / 100);
+}


### PR DESCRIPTION
  * Update: updated media driver to support basic qsfp28-dd revisions.
  * Update: changed err log to tracelog for sfp missing port power cfg.
  * Bugfix: Fixed issue in reading eeprom info as part of presence poll.
  * Bugfix: PSU fan is running at high speed then expected.
  * Update: Restructure of media cables and their management.
  * Update: Added logic to read entity EEPROM & cache contents when entity inserted.
  * Update: Added logic for PPID-dependent resources.
  * Update: Added logic for configurable fan speed RPM-percent mapping for S6K PSU.
  * Update: Added API calls to convert between fan speed RPM and percent.
  * Bugfix: Addressed issue in sensor key generation while adding device from driver init.
  * Bugfux: System reboot time is optimized.
  * Update: Using ipmi_posix_thread_setup_os_handler to handle multiple threads for bmc events and polling.

Signed-off-by: Rakesh Datta <rakesh.datta6@gmail.com>