### PR TITLE
fix: Missing prototype

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.69])
-AC_INIT([opx-sdi-sys], [4.22.2], [ops-dev@lists.openswitch.net])
+AC_INIT([opx-sdi-sys], [4.22.2+opx1], [ops-dev@lists.openswitch.net])
 AM_INIT_AUTOMAKE([foreign subdir-objects])
 AC_CONFIG_SRCDIR([config.h.in])
 AC_CONFIG_HEADERS([config.h])

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+opx-sdi-sys (4.22.2+opx1) unstable; urgency=medium
+
+  * Bugfix: Added missing prototype in sdi_bmc.c
+
+ -- Dell EMC <ops-dev@lists.openswitch.net>  Wed, 29 Aug  2018 15:40:00 -0800
+
 opx-sdi-sys (4.22.2) unstable; urgency=medium
 
   * Update: QSFP Enhancements.

--- a/src/drivers/sdi_bmc.c
+++ b/src/drivers/sdi_bmc.c
@@ -42,6 +42,7 @@
 #include <signal.h>
 #include <string.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 static ipmi_domain_id_t domain_id;
 


### PR DESCRIPTION
sdi_bmc.c was missing a prototype for malloc().

Change-Id: I56ed759e0479cfe5573ceeee8bd228d6504ec8a8
Signed-off-by: Howard Persh <Howard_Persh@dell.com>