### PR TITLE
feat: opx-3.2.0

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018 Dell Inc.
+# Copyright (c) 2019 Dell Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain
@@ -96,8 +96,6 @@ libopx_sdi_device_drivers_la_SOURCES = \
         src/drivers/sdi_pseudo_bus.c \
         src/drivers/sdi_qsfp_4X1_1000baseT.c \
         src/drivers/sdi_qsfp.c \
-        src/drivers/sdi_qsfp28_dd.c \
-        src/drivers/sdi_qsfp28_dd_eeprom.c \
         src/drivers/sdi_qsfp_eeprom.c \
         src/drivers/sdi_s6k_psu.c \
         src/drivers/sdi_segment_display.c \
@@ -109,7 +107,6 @@ libopx_sdi_device_drivers_la_SOURCES = \
         src/drivers/sdi_sfp_eeprom.c \
         src/drivers/sdi_sf_tmp.c \
         src/drivers/sdi_tmp75.c \
-        src/drivers/sdi_fixed_port.c \
         src/drivers/sys-interface-drivers/sdi_gpio.c \
         src/drivers/sys-interface-drivers/sdi_i2cdev.c\
         src/drivers/sys-interface-drivers/sdi_sysfs_gpio_helpers.c \
@@ -122,7 +119,10 @@ libopx_sdi_device_drivers_la_SOURCES = \
         src/drivers/sdi_fpga_pci_bus.c \
         src/drivers/sdi_comm_dev_ext_ctrl.c \
         src/drivers/sdi_platform_util.c \
-        src/drivers/sdi_sf_ext_ctrl.c
+	src/drivers/sdi_sfp_plus_aq.c \
+	src/drivers/sdi_media_ext_mod_ctrl.c \
+        src/drivers/sdi_sf_ext_ctrl.c \
+        src/drivers/sdi_bmc_oem_ext_ctl.c
 
 
 libopx_sdi_device_drivers_la_LIBADD = libopx_sdi_framework.la -lopx_common -lopx_logging -lz -lm -lpthread -lOpenIPMI -lOpenIPMIposix -lOpenIPMIpthread

--- a/cfg/sdi/sdi-db-create.sql
+++ b/cfg/sdi/sdi-db-create.sql
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain
@@ -73,6 +73,15 @@ CREATE TABLE Entity_Resource (
 
     PRIMARY KEY ( Resource_Handle ),
     FOREIGN KEY ( Entity_Handle ) REFERENCES Entity_Info(Entity_Handle)
+);
+
+CREATE TABLE CommDev (
+    Resource_Handle     INTEGER,
+    Service_Tag         TEXT,
+    Firmware_Version    TEXT,
+    Slot_Occupation     INTEGER,
+
+    PRIMARY KEY ( Resource_Handle )
 );
 
 CREATE TABLE Fan (

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018 Dell Inc.
+# Copyright (c) 2019 Dell Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain
@@ -13,12 +13,11 @@
 # See the Apache Version 2.0 License for specific language governing
 # permissions and limitations under the License.
 #
-
 #                                               -*- Autoconf -*-
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.69])
-AC_INIT([opx-sdi-sys], [4.24.0+opx3], [ops-dev@lists.openswitch.net])
+AC_INIT([opx-sdi-sys], [4.25.0], [ops-dev@lists.openswitch.net])
 AM_INIT_AUTOMAKE([foreign subdir-objects])
 AC_CONFIG_SRCDIR([config.h.in])
 AC_CONFIG_HEADERS([config.h])

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,27 @@
+opx-sdi-sys (4.25.0) unstable; urgency=medium
+
+  * Bugfix: Adjust the elm_data offset due to the openIPMI data header removal
+  * Bugfix: Made changes in sdi_bmc_fan_status_get function to return success and 
+            fault status as good when SDI BMC driver doesnt find fan status sensor in BMC sensor list
+  * Update: Separate PSU DC type, AC+DC type, so we can debug the BMC spurious data
+  * Bugfix: Made changes in sdi_bmc_fan_status_get function to return success and 
+            falut status as good when SDI BMC driver doesnt find fan status sensor in BMC sensor list
+  * Bugfix: Reset eeprom version on module init
+  * Bugfix: Address High Sev Coverity issues
+  * Bugfix: Fixed issue in getting the fan status from discrete state sensor
+  * Bugfix: Support rate select on 10gbaseT
+  * Update: Bringing Platform specific changes into device.xml
+  * Update: Changed BITMASK to BIT
+  * Bugfix: S5212F built-in FAN and PSU details are not displayed
+  * Update: Copyright year
+
+ -- Dell EMC <ops-dev@lists.openswitch.net>  Wed, 06 Jun 2019 15:00:00 -0800
+
 opx-sdi-sys (4.24.0+opx3) unstable; urgency=medium
 
   * Update: Copyright information
 
- -- Dell EMC <ops-dev@lists.openswitch.net>  Tue, 11 Dec  2018 15:00:00 -0800
+ -- Dell EMC <ops-dev@lists.openswitch.net>  Tue, 11 Dec 2018 15:00:00 -0800
 
 opx-sdi-sys (4.24.0+opx2) unstable; urgency=medium
 

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,7 +1,7 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 
 Files: *
-Copyright: Copyright (c) 2018 Dell Inc.
+Copyright: Copyright (c) 2019 Dell Inc.
 License: Apache-2.0
 
 License: Apache-2.0

--- a/inc/Makefile.am
+++ b/inc/Makefile.am
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018 Dell Inc.
+# Copyright (c) 2019 Dell Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain
@@ -93,17 +93,17 @@ noinst_HEADERS = \
         opx/private/sdi_register_eeprom_api.h \
         opx/private/sdi_register_fantray_api.h \
         opx/private/util.h \
-        opx/private/sdi_bmc.h \
-        opx/private/sdi_bmc_bus_api.h \
-        opx/private/sdi_bmc_db.h \
-        opx/private/sdi_bmc_internal.h \
-        opx/private/sdi_bmc_io_bus.h \
-        opx/private/sdi_fpga_pci.h \
-        opx/private/sdi_fpga_pci_bus.h \
-        opx/private/sdi_fpga_pci_bus_api.h \
-        opx/private/sdi_fpga_pci_bus_attr.h \
-        opx/private/sdi_fixed_ports.h \
-        opx/private/sdi_qsfp28_dd.h \
+	opx/private/sdi_bmc.h \
+	opx/private/sdi_bmc_bus_api.h \
+	opx/private/sdi_bmc_db.h \
+	opx/private/sdi_bmc_internal.h \
+	opx/private/sdi_bmc_io_bus.h \
+	opx/private/sdi_fpga_pci.h \
+	opx/private/sdi_fpga_pci_bus.h \
+	opx/private/sdi_fpga_pci_bus_api.h \
+	opx/private/sdi_fpga_pci_bus_attr.h \
+        opx/private/sdi_media_ext_mod_ctrl.h \
+        opx/private/sdi_sfp_plus_aq.h \
         opx/unittest/sdi_unit_test.h
 
 # Headers for API (will be included in -dev package)
@@ -111,7 +111,7 @@ nobase_include_HEADERS = \
         opx/sdi_comm_dev.h \
         opx/sdi_entity.h \
         opx/sdi_entity_info.h \
-        opx/sdi_ext_ctrl.h \
+	opx/sdi_ext_ctrl.h \
         opx/sdi_fan.h \
         opx/sdi_host_system.h \
         opx/sdi_led.h \

--- a/inc/opx/private/eeprom/genericideeprom.h
+++ b/inc/opx/private/eeprom/genericideeprom.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/sdi_bmc.h
+++ b/inc/opx/private/sdi_bmc.h
@@ -24,6 +24,7 @@
 
 #include "std_error_codes.h"
 #include "sdi_driver_internal.h"
+#include "sdi_bmc_internal.h"
 
 /**
  * sdi_bmc_device_driver_init is to initialize BMC driver, it establishes
@@ -32,5 +33,10 @@
  */
 t_std_error sdi_bmc_device_driver_init (sdi_device_hdl_t dev_hdl);
 
+/**
+ * sdi_bmc_oem_cmd_execute is to execute OEM specific IPMI command.
+ * 
+ */
+t_std_error sdi_bmc_oem_cmd_execute(sdi_bmc_oem_cmd_info_t *oem_cmd, uint8_t *data);
 
 #endif /* __SDI_BMC_H__ */

--- a/inc/opx/private/sdi_bmc_internal.h
+++ b/inc/opx/private/sdi_bmc_internal.h
@@ -40,13 +40,36 @@
 #define SDI_BMC_DEV_ATTR_EEPROM         "bmc_eeprom"
 #define SDI_BMC_DEV_ATTR_DATA           "data_sdr_id"
 #define SDI_BMC_DEV_ATTR_STATUS         "status_sdr_id"
+#define SDI_BMC_DEV_ATTR_STATUS_BIT     "status_bit"
+#define SDI_BMC_OEM_ATTR_DATA           "oem_status"
+#define SDI_BMC_DEV_ATTR_OEM_POLLER     "oem_poller"
+#define SDI_BMC_DEV_ATTR_SENSR_REQ      "sensor_req"
+#define SDI_BMC_DEV_ATTR_SENSR_REQ_BIT  "sensor_req_bit"
+#define SDI_BMC_DEV_ATTR_OEM_STATUS_SDR "oem_status_sdr"
+#define SDI_BMC_DEV_ATTR_OEM_NETFN      "oem_netfn"
+#define SDI_BMC_DEV_ATTR_OEM_CMD        "oem_cmd"
+#define SDI_BMC_DEV_ATTR_OEM_BUSID      "oem_busid"
+#define SDI_BMC_DEV_ATTR_OEM_SLAVE_ADDR "oem_slave_addr"
+#define SDI_BMC_DEV_ATTR_OEM_DATA_SIZE  "oem_data_size"
+#define SDI_BMC_DEV_ATTR_OEM_OFFSET     "oem_offset"
+#define SDI_BMC_DEV_ATTR_OEM_DATA       "oem_data"
+
 
 #define SDI_BMC_INT_USE_ELM_OFFSET      "int_use_elm_offset"
 #define SDI_BMC_AIRFLOW_OFFSET          "airflow_offset"
 #define SDI_BMC_PSU_TYPE_OFFSET         "psu_type_offset"
+#define SDI_BMC_HDR_SZ_OFFSET           "hdr_sz_offset"
+#define SDI_BMC_ENTITY_INFO_DUMMY       "entity_info_dummy"
+#define SDI_BMC_OEM_PSU_TYPE            "oem_psu_type"
+#define SDI_BMC_OEM_AIRFLOW             "oem_airflow"
 
 #define SDI_BMC_MAX_INT_USE_AREA        (256)
 #define SDI_BMC_INVALID_OFFSET          (0xFFFFFFFF)
+#define SDI_BMC_HDR_SZ_OFFSET_DEF       (0)
+#define SDI_BMC_OEM_DATA_LEN            33
+
+#define SDI_BMC_INVALID_BIT             (0xff)
+
 /*
  * BMC entity info offsets.
  */
@@ -83,6 +106,7 @@ typedef enum {
     SDI_SDR_READING_THRESHOLD = 1,
     SDI_SDR_READING_DISCRETE = 2,
     SDI_SDR_READING_ENTITY_INFO = 3,
+    SDI_SDR_READING_OEM_DISCRETE = 4
 } sdi_sdr_rd_type_t;
 
 /*
@@ -104,6 +128,8 @@ typedef struct sdi_bmc_entity_info_s {
     uint8_t  type; /* This field is applicable for PSU's only */
     int      num_fans; /* Number of fans in entity instance */
     int      max_speed; /* Max fan speed of the fan */
+    bool     is_dummy;  /* If BMC FRU implementation not available,
+                           use this flag and populate dummy eeprom info */
 } sdi_bmc_entity_info_t;
 
 /*
@@ -145,6 +171,40 @@ typedef struct sdi_bmc_sensor_s {
     double              threshold[MAX_THRESHOLDS]; /** BMC configured threshold values */
 } sdi_bmc_sensor_t;
 
+
+
+/*
+ * BMC OEM speicific IPMI command details
+ *
+ */
+typedef struct sdi_bmc_oem_cmd_info_s {
+    uint32_t             netfn;
+    uint32_t             cmd;
+    uint32_t             bus_id;
+    uint32_t             slave_addr;
+    uint32_t             offset;
+    uint32_t             data_size;
+    uint8_t              data;
+    uint8_t              req_data[SDI_BMC_OEM_DATA_LEN + 4];
+    uint8_t              *resp_data;
+} sdi_bmc_oem_cmd_info_t;
+
+/*
+ * BMC OEM specific IPMI Poller
+ */
+typedef struct sdi_bmc_oem_poller_s {
+    std_dll                     node;
+    int                         oem_cmd_count;
+    char                        sensor[SDI_MAX_NAME_LEN];
+    uint32_t                    sensor_bit;
+    uint32_t                    *sensor_loc;
+    sdi_bmc_oem_cmd_info_t      *oem_cmd;
+} sdi_bmc_oem_poller_t;
+
+#define BMC_AC_TYPE     0
+#define BMC_DC_TYPE     1
+#define BMC_AC_DC_TYPE  2
+
 /*
  * SDI resource info its used to create map between sdi resource
  * to BMC sensors. 
@@ -156,13 +216,18 @@ typedef struct sdi_bmc_dev_resource_info_s {
     char                data_sdr_id[SDI_MAX_NAME_LEN]; /** Data sensor id */
     sdi_bmc_sensor_t    *data_sdr; /** Data sensor record */
     char                status_sdr_id[SDI_MAX_NAME_LEN]; /** Status sensor Id */
+    uint_t              status_bit; /** Status bit which needs to be checked */
     sdi_bmc_sensor_t    *status_sdr; /** Status sensor record */
     uint32_t            int_use_elm_offset; /* Internal use area element offset */
     uint32_t            airflow_offset; /* Airflow data offset in element data */
     uint32_t            psu_type_offset; /* PSU type data offset in element data */
+    sdi_bmc_oem_cmd_info_t *psu_type_oem_cmd; /* PSU Type retrived through OEM command */
+    sdi_bmc_oem_cmd_info_t *air_flow_oem_cmd; /* Air Flow Direction retrived through OEM command */
     uint32_t            fan_count;   /** Number fans present in this entity */
     uint32_t            max_fan_speed /** Max fan speed */;
     sdi_device_hdl_t    dev_hdl;  /** Device handle */
+    uint32_t            hdr_sz_offset; /* OpenIPMI API will strip header, making eeprom offset adjustment necessary */
+    bool                is_dummy; /** Is BMC FRU support available? if not dummy should be true */
 } sdi_bmc_dev_resource_info_t;
 
 /**
@@ -173,6 +238,7 @@ typedef struct sdi_bmc_dev_list_s {
     sdi_bmc_dev_resource_info_t  data[0]; /** Resource info list */
 } sdi_bmc_dev_list_t;
 
+
 /*
  * BMC device config 
  */
@@ -181,10 +247,16 @@ typedef struct sdi_bmc_dev_s {
     uint32_t            polling_interval; /** Polling interval */
     char                alias[SDI_MAX_NAME_LEN]; /** BMC device alias */
     sdi_bmc_dev_list_t  *dev_list; /** Device list */
+    std_dll_head        *oem_poller_head; /** OEM command list */
 } sdi_bmc_dev_t;
 
+
 /*
- *
+ * Populate OEM Specific IPMI command info from config node
+ */
+void  sdi_bmc_populate_oem_cmd_info (std_config_node_t node, sdi_bmc_oem_cmd_info_t *oem_info);
+/*
+ * Get BMC device for given sdr Id. 
  */
 
 sdi_bmc_dev_resource_info_t * sdi_bmc_dev_get_by_data_sdr (sdi_device_hdl_t dev_hdl, char *sdr_id);

--- a/inc/opx/private/sdi_bus.h
+++ b/inc/opx/private/sdi_bus.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/sdi_bus_api.h
+++ b/inc/opx/private/sdi_bus_api.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/sdi_bus_attr.h
+++ b/inc/opx/private/sdi_bus_attr.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/sdi_bus_framework.h
+++ b/inc/opx/private/sdi_bus_framework.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/sdi_comm_dev_attr.h
+++ b/inc/opx/private/sdi_comm_dev_attr.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/sdi_comm_dev_internal.h
+++ b/inc/opx/private/sdi_comm_dev_internal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/sdi_common_attr.h
+++ b/inc/opx/private/sdi_common_attr.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/sdi_cpld.h
+++ b/inc/opx/private/sdi_cpld.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/sdi_cpld_attr.h
+++ b/inc/opx/private/sdi_cpld_attr.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/sdi_cpld_driver_attr.h
+++ b/inc/opx/private/sdi_cpld_driver_attr.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/sdi_db.h
+++ b/inc/opx/private/sdi_db.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain
@@ -115,6 +115,8 @@ void sdi_db_reinit_database(void);
 #define TABLE_NVRAM             "NVRAM"
 /** Writable External Control */
 #define TABLE_EXT_CTRL          "External_Ctrl"
+/** Comm Dev */
+#define TABLE_COMMDEV           "CommDev"
 
 /**
  * @}
@@ -169,6 +171,21 @@ void sdi_db_reinit_database(void);
 #define DIGIT_LED_DISPLAY       "Display_String"
 /** Digit display LED State */
 #define DIGIT_LED_STATE         "Display_On"
+
+/**
+ * @}
+ */
+
+/** @defgroup sdi_table_thermal SDI VM DB CommDev  table fields
+ *
+ * @ingroup sdi_table
+ * @{
+ */
+
+/** CommDev State */
+#define COMMDEV_SERVICE_TAG             "Service_Tag"
+#define COMMDEV_FW_VER                  "Firmware_Version"
+#define COMMDEV_SLOT_ID                 "Slot_Occupation"
 
 /**
  * @}

--- a/inc/opx/private/sdi_db_config.h
+++ b/inc/opx/private/sdi_db_config.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/sdi_dell_eeprom.h
+++ b/inc/opx/private/sdi_dell_eeprom.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/sdi_device_common.h
+++ b/inc/opx/private/sdi_device_common.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/sdi_driver_internal.h
+++ b/inc/opx/private/sdi_driver_internal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/sdi_eeprom.h
+++ b/inc/opx/private/sdi_eeprom.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/sdi_emc142x_reg.h
+++ b/inc/opx/private/sdi_emc142x_reg.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/sdi_emc2305.h
+++ b/inc/opx/private/sdi_emc2305.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/sdi_entity_info_internal.h
+++ b/inc/opx/private/sdi_entity_info_internal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/sdi_entity_info_resource_attr.h
+++ b/inc/opx/private/sdi_entity_info_resource_attr.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain
@@ -86,6 +86,46 @@
  * @def Attribute value for representing DC powertype
  */
 #define SDI_DEV_ATTR_DC_POWER_VAL             "dc_power_val"
+
+/**
+ * @def Attribute value to know PSU_TYPE and FAN_AF based on sys part number
+ */
+#define SDI_DEV_ATTR_PART_NUMBER_BASED_SYS     "part_no_based_sys"
+
+/**
+ * @def Attribute value to know PSU_TYPE and FAN_AF based on sys part number
+ */
+#define SDI_DEV_ATTR_SYS_PART_NUMBER_BASED_ENTY  "part_no_based_enty"
+
+/**
+ * @def Attribute value for representing MAX part number types
+ */
+#define SDI_DEV_ATTR_MAX_PART_NO_TYPES         "max_part_no_types"
+
+/**
+ * @def Attribute value representing airflow value of specific part_no type
+ */
+#define SDI_DEV_ATTR_AIRFLOW_VALUE             "airflow_val"
+
+/**
+ * @def Attribute value representing PSU AC type val of specific part_no type
+ */
+#define SDI_DEV_ATTR_PSU_AC_TYPE_VAL           "ac_type"
+
+/**
+ * @def Attribute value representing PSU DC type val of specific part_no type
+ */
+#define SDI_DEV_ATTR_PSU_DC_TYPE_VAL           "dc_type"
+
+/**
+ * @def Attribute value for representing part number
+ */
+#define SDI_DEV_ATTR_PART_NO                   "part_no"
+
+/**
+ * @def Attribute value for representing part number mapping node
+ */
+#define SDI_DEV_PART_NUM_MAP_NODE              "part_no_mapping"
 
 /**
  * @}

--- a/inc/opx/private/sdi_entity_info_vdriver.h
+++ b/inc/opx/private/sdi_entity_info_vdriver.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain
@@ -38,31 +38,57 @@
 t_std_error sdi_entity_info_data_get(void *resource_hdl,
                                      sdi_entity_info_t *entity_info);
 
+
 /**
+**
  * @struct entity_info_t
  * ENTITY INFO (virtual device) private data
  */
 typedef struct {
     /** Store the current entity info data */
-    /**< No.of fan in the entity */   
-    uint_t                    no_of_fans;            
+    /**< No.of fan in the entity */
+    uint_t                    no_of_fans;
     /**< Max Speed of the fan in the entity */
-    uint_t                    max_fan_speed;         
+    uint_t                    max_fan_speed;
     /**< SDI pin group bus hdl for obtaining fan airflow dir */
-    sdi_pin_group_bus_hdl_t   airflow_dir_hdl;       
-    /**< SDI pin bus hdl for obtaining psu power type: ac or dc */      
-    sdi_pin_bus_hdl_t         psu_type_hdl;          
+    sdi_pin_group_bus_hdl_t   airflow_dir_hdl;
+    /**< SDI pin bus hdl for obtaining psu power type: ac or dc */
+    sdi_pin_bus_hdl_t         psu_type_hdl;
     /**< H/w specified value for normal airflow dir on this platform */
-    uint_t                    normal_airflow_val;    
+    uint_t                    normal_airflow_val;
     /**< H/w specified value for reverse airflow dir on this platform */
-    uint_t                    reverse_airflow_val;   
+    uint_t                    reverse_airflow_val;
     /**< H/w specified value for ac power type on this platform */
-    uint_t                    ac_power_val;          
+    uint_t                    ac_power_val;
     /**< H/w specified value for dc power type on this platform */
-    uint_t                    dc_power_val;          
+    uint_t                    dc_power_val;
+    /** Part number based PSU type and AF dir entity */
+    bool                      part_num_based_ent;
     /**< Device Alias */
     char                      alias[SDI_MAX_NAME_LEN];
 }entity_info_data_t ;
+
+/**
+**
+ * @sdi_partnum_psu_af_map_t
+ * Part num based PSU_TYPE and AF mapping info(virtual device built-in FRUs)
+ */
+typedef struct {
+    /**< Fan airflow dir corresponding to sys part number*/
+    uint_t   airflow_dir_t;
+    /**< psu power type: ac corresponding to sys part number*/
+    bool   psu_ac_type_t;
+    /**< psu power type: dc corresponding to sys part number*/
+    bool   psu_dc_type_t;
+    /**< Device part number len*/
+    char     partno[SDI_PART_NUM_LEN-1];
+}sdi_partnum_psu_af_map_t;
+
+/**
+ * System part number get from EEPROM to use it in Vdriver
+ *for Virtual entities AF and PSU type depends on sys part number
+ */
+void sdi_sys_part_number_get(char *part_num);
 
 /**
  * @}

--- a/inc/opx/private/sdi_entity_internal.h
+++ b/inc/opx/private/sdi_entity_internal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain
@@ -52,6 +52,7 @@ typedef enum {
     SDI_ENT_ACCESS_BMC,    /** Via BMC */
 } sdi_entity_access_type_t;
 
+
 /**
  * @struct sdi_entity_t
  * entity data structure which contains details of an entity
@@ -71,6 +72,7 @@ struct sdi_entity {
     sdi_pin_bus_hdl_t power_output_status_pin_hdl; /**<psu power output
                                                     * status handler */
     char pres_attr[SDI_MAX_NAME_LEN]; /** presence attr configured in entity.xml */
+    uint_t pres_bit; /** Presence bit number in the specified status register. */
     sdi_pin_bus_hdl_t pres_pin_hdl; /**<presence handler */
     sdi_pin_bus_hdl_t fault_status_pin_hdl; /**<fault status handler */
     sdi_pin_bus_hdl_t power_pin_hdl; /**<power ON/OFF handler */

--- a/inc/opx/private/sdi_fan_internal.h
+++ b/inc/opx/private/sdi_fan_internal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/sdi_fan_resource_attr.h
+++ b/inc/opx/private/sdi_fan_resource_attr.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/sdi_fixed_ports.h
+++ b/inc/opx/private/sdi_fixed_ports.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/sdi_fpga_pci_bus.h
+++ b/inc/opx/private/sdi_fpga_pci_bus.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/sdi_gpio.h
+++ b/inc/opx/private/sdi_gpio.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/sdi_host_system_internal.h
+++ b/inc/opx/private/sdi_host_system_internal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/sdi_i2c.h
+++ b/inc/opx/private/sdi_i2c.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/sdi_i2c_bus_api.h
+++ b/inc/opx/private/sdi_i2c_bus_api.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/sdi_i2c_bus_framework.h
+++ b/inc/opx/private/sdi_i2c_bus_framework.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/sdi_i2c_mux_attr.h
+++ b/inc/opx/private/sdi_i2c_mux_attr.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/sdi_i2cdev.h
+++ b/inc/opx/private/sdi_i2cdev.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/sdi_i2cmux_pca.h
+++ b/inc/opx/private/sdi_i2cmux_pca.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/sdi_i2cmux_pin.h
+++ b/inc/opx/private/sdi_i2cmux_pin.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/sdi_ina219_reg.h
+++ b/inc/opx/private/sdi_ina219_reg.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/sdi_io_port_api.h
+++ b/inc/opx/private/sdi_io_port_api.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/sdi_led_internal.h
+++ b/inc/opx/private/sdi_led_internal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/sdi_max6620.h
+++ b/inc/opx/private/sdi_max6620.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/sdi_max6699_reg.h
+++ b/inc/opx/private/sdi_max6699_reg.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/sdi_media_attr.h
+++ b/inc/opx/private/sdi_media_attr.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/sdi_media_ext_mod_ctrl.h
+++ b/inc/opx/private/sdi_media_ext_mod_ctrl.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ * LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
+/*
+ * filename: sdi_media_ext_mod_ctrl.h
+ */
+
+
+#ifndef _SDI_MEDIA_EXT_MOD_CTRL_H_
+#define _SDI_MEDIA_EXT_MOD_CTRL_H_
+
+#include "sdi_media.h"
+#include "sdi_sfp.h"
+#include "sdi_resource_internal.h"
+#include "sdi_device_common.h"
+#include "sdi_pin_group_bus_framework.h"
+#include "sdi_pin_group_bus_api.h"
+#include "sdi_i2c_bus_api.h"
+#include "std_error_codes.h"
+#include "std_assert.h"
+#include "std_time_tools.h"
+#include <stdlib.h>
+#include <string.h>
+
+
+
+#define EXT_MEM_SIZE                  6
+#define OPER_MASK                     3
+#define DATA_BUF_SIZE                 2
+#define STATUS_POLL_IDLE_STATE        0
+#define STATUS_POLL_COMPLETE_STATE    1
+#define STATUS_POLL_ERROR_STATE       2
+#define STATUS_POLL_MAX_TIMEOUT_MS    100
+#define STATUS_POLL_INTERVAL_MS    (STATUS_POLL_MAX_TIMEOUT_MS/10)
+
+#define STATUS_OPER_COMPLETE_BITMASK    ((1 << 2) | (1 << 3))
+
+typedef enum{
+    AQ_TX_STATE_SET_ADDR = 0x1,
+    AQ_CURR_LINK_STATE_ADDR = 0x1,
+    AQ_SYS_STATUS_GET_ADDR = 0x4,
+    AQ_LINE_SIDE_LINK_RATE_ADDR = 0x7,
+    AQ_RATE_SET_MEM_ADDR = 0x7,
+    AQUANTIA_10G_T = 7,
+} ext_mem_addr_t;
+
+typedef enum{
+
+    MEM_READ    = 1,
+    MEM_WRITE   = 2
+} ext_mem_oper_t;
+
+typedef struct {
+    ext_mem_addr_t mem_addr;
+    uint16_t reg_offset;
+    uint16_t data_buf_big_endian;
+    ext_mem_oper_t oper;
+} ext_dev_ctrl_oper_packet_t;
+
+t_std_error sdi_media_ext_mod_ctrl_chain_oper (sdi_resource_hdl_t resource_hdl, ext_dev_ctrl_oper_packet_t* packets, size_t num_packets);
+
+#endif

--- a/inc/opx/private/sdi_media_internal.h
+++ b/inc/opx/private/sdi_media_internal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/sdi_media_phy_mgmt.h
+++ b/inc/opx/private/sdi_media_phy_mgmt.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain
@@ -116,5 +116,42 @@ t_std_error sdi_qsfp_4X1_1000baseT_speed_set (sdi_device_hdl_t qsfp_device,
 t_std_error sdi_qsfp_4X1_1000baseT_autoneg_set (sdi_device_hdl_t qsfp_device,
                                                 uint_t channel, bool enable);
 
+
+/**
+ * @brief Api to  set speed  on media PHY.
+ * @param[in] resource_hdl - handle to media
+ * @param[in] speed - speed of the interface. Should be of type @ref sdi_media_speed_t .
+ * @return - standard @ref t_std_error
+ *
+ */
+
+t_std_error sdi_cusfp_plus_phy_speed_set(sdi_device_hdl_t sfp_device, sdi_media_speed_t speed);
+
+/**
+ * @brief Api to get link status from media PHY.
+ * @param[in] resource_hdl - handle to media
+ * @param[in] status - true when link is up, false when link is down
+ * @return - standard @ref t_std_error
+ *
+ */
+t_std_error sdi_cusfp_plus_phy_link_status_get (sdi_device_hdl_t sfp_device, bool *status);
+
+/**
+ * @brief Api to enable/disable the Fiber/Serdes TX and RX on media PHY.
+ * @param[in] resource_hdl - handle to media
+ * @param[in] enable - true enable Serdes, false - Disable Serdes.
+ * @return - standard @ref t_std_error
+ *
+ */
+t_std_error sdi_cusfp_plus_phy_serdes_control (sdi_device_hdl_t sfp_device, bool enable);
+
+/**
+ * @brief Api to get line side speed on media PHY.
+ * @param[in] resource_hdl - handle to media
+ * @param[out] speed - speed of line side
+ * @return - standard @ref t_std_error
+ *
+ */
+t_std_error sdi_cusfp_plus_phy_speed_get(sdi_device_hdl_t sfp_device, sdi_media_speed_t* speed);
 #endif
 

--- a/inc/opx/private/sdi_nvram_internal.h
+++ b/inc/opx/private/sdi_nvram_internal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/sdi_nvram_resource_attr.h
+++ b/inc/opx/private/sdi_nvram_resource_attr.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/sdi_onie_eeprom.h
+++ b/inc/opx/private/sdi_onie_eeprom.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/sdi_pin.h
+++ b/inc/opx/private/sdi_pin.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/sdi_pin_bus_api.h
+++ b/inc/opx/private/sdi_pin_bus_api.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/sdi_pin_bus_attr.h
+++ b/inc/opx/private/sdi_pin_bus_attr.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/sdi_pin_bus_framework.h
+++ b/inc/opx/private/sdi_pin_bus_framework.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/sdi_pin_group.h
+++ b/inc/opx/private/sdi_pin_group.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/sdi_pin_group_bus_api.h
+++ b/inc/opx/private/sdi_pin_group_bus_api.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/sdi_pin_group_bus_framework.h
+++ b/inc/opx/private/sdi_pin_group_bus_framework.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/sdi_pld_upgrade_internal.h
+++ b/inc/opx/private/sdi_pld_upgrade_internal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/sdi_pmbus_dev.h
+++ b/inc/opx/private/sdi_pmbus_dev.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/sdi_power_monitor_internal.h
+++ b/inc/opx/private/sdi_power_monitor_internal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/sdi_power_monitor_resource_attr.h
+++ b/inc/opx/private/sdi_power_monitor_resource_attr.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/sdi_qsfp.h
+++ b/inc/opx/private/sdi_qsfp.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/sdi_qsfp28_dd.h
+++ b/inc/opx/private/sdi_qsfp28_dd.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/sdi_qsfp_reg.h
+++ b/inc/opx/private/sdi_qsfp_reg.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/sdi_register_common_api.h
+++ b/inc/opx/private/sdi_register_common_api.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/sdi_register_eeprom_api.h
+++ b/inc/opx/private/sdi_register_eeprom_api.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/sdi_register_fantray_api.h
+++ b/inc/opx/private/sdi_register_fantray_api.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/sdi_resource_internal.h
+++ b/inc/opx/private/sdi_resource_internal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/sdi_sf_entity_info_attr.h
+++ b/inc/opx/private/sdi_sf_entity_info_attr.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/sdi_sf_fan_attr.h
+++ b/inc/opx/private/sdi_sf_fan_attr.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/sdi_sf_io_bus.h
+++ b/inc/opx/private/sdi_sf_io_bus.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/sdi_sf_io_bus_attr.h
+++ b/inc/opx/private/sdi_sf_io_bus_attr.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/sdi_sf_tmp_attr.h
+++ b/inc/opx/private/sdi_sf_tmp_attr.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/sdi_sfp.h
+++ b/inc/opx/private/sdi_sfp.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/sdi_sfp_plus_aq.h
+++ b/inc/opx/private/sdi_sfp_plus_aq.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ * LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
+/*
+ * filename: sdi_sfp_plus_aq.h
+ */
+
+#ifndef _SDI_SFP_PLUS_AQ_H_ 
+#define _SDI_SFP_PLUS_AQ_H_
+
+#include "sdi_media_ext_mod_ctrl.h"
+#include "sdi_media.h"
+
+
+t_std_error sdi_media_aq_set_rate (sdi_resource_hdl_t resource_hdl, sdi_media_speed_t rate);
+t_std_error sdi_media_aq_get_system_side_status (sdi_resource_hdl_t resource_hdl, bool *rx_if_link_status, bool *tx_if_link_status,
+                    sdi_media_speed_t *if_speed_rate);
+t_std_error sdi_media_aq_set_tx_state (sdi_resource_hdl_t resource_hdl, bool state);
+t_std_error sdi_media_aq_get_tx_state (sdi_resource_hdl_t resource_hdl, bool *state);
+t_std_error sdi_media_aq_get_line_side_status (sdi_resource_hdl_t resource_hdl, bool *link_status, sdi_media_speed_t *link_speed_rate);
+t_std_error sdi_media_aq_get_link_status(sdi_resource_hdl_t resource_hdl, bool* status);
+
+#endif

--- a/inc/opx/private/sdi_sfp_reg.h
+++ b/inc/opx/private/sdi_sfp_reg.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain
@@ -67,6 +67,7 @@ typedef enum {
     SFP_ENHANCED_OPTIONS_OFFSET     = 93,
     SFP_CC_EXT_OFFSET               = 95,
     SFP_DELL_PRODUCT_ID_OFFSET         = 96,
+    SFP_EXT_MOD_CTRL_SUPPORT_OFFSET = 101,
     SFP_INTERNAL_PART_NUMBER_OFFSET = 134,
 } sfp_reg_offset_t;
 
@@ -310,4 +311,7 @@ typedef enum {
 #define SFP_PLUS_CABLE_TECH_MASK       (0x3)  /* SFP+ Cable Technology mask */
 #define SFP_PLUS_CABLE_TECH_BIT_SHIFT  (2)
 
+
+/* Extmod ctrl */
+#define SFP_EXT_MOD_CTRL_BIT            (0)
 #endif

--- a/inc/opx/private/sdi_smartfusion_io.h
+++ b/inc/opx/private/sdi_smartfusion_io.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/sdi_smartfusion_io_bus_api.h
+++ b/inc/opx/private/sdi_smartfusion_io_bus_api.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/sdi_sys_common.h
+++ b/inc/opx/private/sdi_sys_common.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/sdi_sys_vm.h
+++ b/inc/opx/private/sdi_sys_vm.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/sdi_sysfs_gpio_helpers.h
+++ b/inc/opx/private/sdi_sysfs_gpio_helpers.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/sdi_temperature_resource_attr.h
+++ b/inc/opx/private/sdi_temperature_resource_attr.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/sdi_thermal_internal.h
+++ b/inc/opx/private/sdi_thermal_internal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/sdi_tmp75_reg.h
+++ b/inc/opx/private/sdi_tmp75_reg.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/sdi_vm_sys_init.h
+++ b/inc/opx/private/sdi_vm_sys_init.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/private/util.h
+++ b/inc/opx/private/util.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/sdi_comm_dev.h
+++ b/inc/opx/sdi_comm_dev.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/sdi_entity.h
+++ b/inc/opx/sdi_entity.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/sdi_entity_info.h
+++ b/inc/opx/sdi_entity_info.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/sdi_fan.h
+++ b/inc/opx/sdi_fan.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/sdi_host_system.h
+++ b/inc/opx/sdi_host_system.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/sdi_led.h
+++ b/inc/opx/sdi_led.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/sdi_media.h
+++ b/inc/opx/sdi_media.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain
@@ -437,6 +437,10 @@ typedef enum {
  */
 typedef enum {
     /**
+     * SDI MEDIA Invalid Speed
+     */
+    SDI_MEDIA_INVALID_SPEED = -1,
+    /**
      * SDI MEDIA Speed is 10Mbps
      */
     SDI_MEDIA_SPEED_10M,
@@ -448,6 +452,11 @@ typedef enum {
      * SDI MEDIA Speed is 1G
      */
     SDI_MEDIA_SPEED_1G,
+
+    /**
+     * 2.5Gbps and 5Gbps are defined at bottom as SDI_MEDIA_SPEED_2500M and SDI_MEDIA_SPEED_5G
+     */
+
     /**
      * SDI MEDIA Speed is 10G
      */
@@ -496,6 +505,14 @@ typedef enum {
      * SDI MEDIA Speed is 32GFC
      */
     SDI_MEDIA_SPEED_32GFC,
+    /**
+     * SDI MEDIA Speed is 2.5Gbps
+     */
+    SDI_MEDIA_SPEED_2500M,
+    /**
+     * SDI MEDIA Speed is 5G
+     */
+    SDI_MEDIA_SPEED_5G,
 }sdi_media_speed_t;
 
 /**
@@ -1152,6 +1169,7 @@ typedef struct {
     bool tx_control_support_status;
     bool paging_support_status;
     bool software_controlled_power_mode_status;
+    bool ext_mod_ctrl_support_status;
 } sdi_qsfp_supported_feature_t;
 
 /**
@@ -1163,6 +1181,7 @@ typedef struct {
     bool alarm_support_status;
     bool diag_mntr_support_status;
     bool wavelength_tune_support_status;
+    bool ext_mod_ctrl_support_status;
 } sdi_sfp_supported_feature_t;
 
 /**

--- a/inc/opx/sdi_nvram.h
+++ b/inc/opx/sdi_nvram.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/sdi_power_monitor.h
+++ b/inc/opx/sdi_power_monitor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/sdi_thermal.h
+++ b/inc/opx/sdi_thermal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/inc/opx/unittest/sdi_unit_test.h
+++ b/inc/opx/unittest/sdi_unit_test.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/drivers/sdi_bmc_entity_info.c
+++ b/src/drivers/sdi_bmc_entity_info.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain
@@ -98,12 +98,17 @@ t_std_error sdi_bmc_entity_info_data_get(void *resource_hdl,
         entity_info->air_flow = SDI_PWR_AIR_FLOW_REVERSE;
     }
 
-    if (sensor->res.entity_info.type == 0x0) {
+    if (sensor->res.entity_info.type == BMC_AC_TYPE) {
         entity_info->power_type.ac_power = 1;
         entity_info->power_type.dc_power = 0;
-    } else {
+    } else if (sensor->res.entity_info.type == BMC_DC_TYPE) {
         entity_info->power_type.ac_power = 0;
         entity_info->power_type.dc_power = 1;
+    } else if (sensor->res.entity_info.type == BMC_AC_DC_TYPE) {
+        entity_info->power_type.ac_power = 1;
+        entity_info->power_type.dc_power = 1;
+    } else {
+        return SDI_DEVICE_ERRCODE(EINVAL); /* BMC has returned unexpected data */
     }
 
     entity_info->num_fans = sensor->res.entity_info.num_fans;
@@ -167,6 +172,7 @@ t_std_error sdi_bmc_entity_info_res_register (sdi_device_hdl_t bmc_dev_hdl, sdi_
     }
     bmc_res->data_sdr->res.entity_info.num_fans = bmc_res->fan_count;
     bmc_res->data_sdr->res.entity_info.max_speed = bmc_res->max_fan_speed;
+    bmc_res->data_sdr->res.entity_info.is_dummy = bmc_res->is_dummy;
     sdi_resource_add(bmc_res->resource_type, bmc_res->alias, dev_hdl, &bmc_entity_info_callback);
     return STD_ERR_OK;
 }

--- a/src/drivers/sdi_bmc_oem_ext_ctl.c
+++ b/src/drivers/sdi_bmc_oem_ext_ctl.c
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2019 Dell EMC..
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *  LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
+/*
+ * filename: sdi_bmc_oem_ext_ctrl.c
+ */
+
+#include "sdi_driver_internal.h"
+#include "sdi_entity.h"
+#include "sdi_resource_internal.h"
+#include "std_assert.h"
+#include "std_utils.h"
+#include "sdi_device_common.h"
+#include "sdi_ext_ctrl_internal.h"
+#include "sdi_bmc_internal.h"
+#include "sdi_bmc.h"
+#include "sdi_common_attr.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+const sdi_driver_t *sdi_bmc_oem_ext_ctrl_entry_callbacks (void);
+
+static t_std_error bmc_oem_ext_ctrl_set(void *resource_hdl, int *ext_ctrl, int size)
+{
+    sdi_device_hdl_t chip = NULL;
+    sdi_bmc_oem_cmd_info_t *ext_ctrl_data = NULL;
+    t_std_error rc = STD_ERR_OK;
+
+    STD_ASSERT(resource_hdl != NULL);
+    STD_ASSERT(ext_ctrl != NULL);
+
+    chip = (sdi_device_hdl_t)resource_hdl;
+
+    ext_ctrl_data = (sdi_bmc_oem_cmd_info_t *)chip->private_data;
+    STD_ASSERT(ext_ctrl_data != NULL);
+
+    rc = sdi_bmc_oem_cmd_execute(ext_ctrl_data, (uint8_t *)ext_ctrl);
+    if(rc != STD_ERR_OK) {
+        SDI_DEVICE_ERRMSG_LOG("bmc_oem_ext_ctrl : set value failed with rc=0x%x\n", rc);
+        return rc;
+    }
+
+    return rc;
+}
+
+static ext_ctrl_t bmc_oem_ext_ctrl = {
+    NULL,
+    NULL,
+    bmc_oem_ext_ctrl_set,
+};
+
+t_std_error bmc_oem_ext_ctrl_register(std_config_node_t node,void *bus_handle,sdi_device_hdl_t* device_hdl)
+{
+    char *node_attr = NULL;
+    sdi_device_hdl_t chip = NULL;
+    sdi_bmc_oem_cmd_info_t *ext_ctrl_data = NULL;
+    char name[SDI_MAX_NAME_LEN];
+
+    STD_ASSERT(node != NULL);
+    STD_ASSERT(bus_handle != NULL);
+    STD_ASSERT(device_hdl != NULL);
+    STD_ASSERT(((sdi_bus_t*)bus_handle)->bus_type == SDI_BMC_IO_BUS);
+
+    chip = calloc(sizeof(sdi_device_entry_t),1);
+    STD_ASSERT(chip != NULL);
+
+    ext_ctrl_data = calloc(sizeof(sdi_bmc_oem_cmd_info_t),1);
+    STD_ASSERT(ext_ctrl_data != NULL);
+
+
+    chip->bus_hdl = bus_handle;
+
+    node_attr = std_config_attr_get(node, SDI_DEV_ATTR_INSTANCE);
+    if (node_attr != NULL) {
+        chip->instance = (uint_t) strtoul(node_attr, NULL, 0);
+    } else {
+        chip->instance = 0;
+    }
+
+    chip->callbacks = sdi_bmc_oem_ext_ctrl_entry_callbacks();
+    chip->private_data = (void*)ext_ctrl_data;
+
+    node_attr = std_config_attr_get(node, SDI_DEV_ATTR_ALIAS);
+    if (node_attr == NULL)
+    {
+        snprintf(chip->alias,SDI_MAX_NAME_LEN,"bmc_oem_ext_ctrl-%d", chip->instance );
+    }
+    else
+    {
+        safestrncpy(chip->alias,node_attr,SDI_MAX_NAME_LEN);
+    }
+
+    node_attr = std_config_attr_get(node, SDI_DEV_ATTR_NAME);
+    if (node_attr != NULL)
+    {
+        safestrncpy(name, node_attr, SDI_MAX_NAME_LEN);
+    } else {
+        safestrncpy(name, chip->alias, SDI_MAX_NAME_LEN);
+    }
+
+
+    sdi_bmc_populate_oem_cmd_info(node, ext_ctrl_data);
+    
+    // The name in the entity reference is the key to find the ext ctrl
+    sdi_resource_add(SDI_RESOURCE_EXT_CONTROL, name, (void*)chip,
+                     &bmc_oem_ext_ctrl);
+    *device_hdl = chip;
+
+    return STD_ERR_OK;
+}   
+
+t_std_error bmc_oem_ext_ctrl_chip_init(sdi_device_hdl_t device_hdl)
+{
+    return STD_ERR_OK;
+}
+
+const sdi_driver_t *sdi_bmc_oem_ext_ctrl_entry_callbacks (void)
+{
+    /* Export the Driver table */
+    static const sdi_driver_t bmc_oem_ext_ctrl_entry = {
+        bmc_oem_ext_ctrl_register,
+        bmc_oem_ext_ctrl_chip_init
+    };
+
+    return &bmc_oem_ext_ctrl_entry;
+};

--- a/src/drivers/sdi_comm_dev_driver.c
+++ b/src/drivers/sdi_comm_dev_driver.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain
@@ -413,7 +413,7 @@ static t_std_error sdi_write_sensor_07_telemetry(sdi_resource_hdl_t resource_hdl
 
 static t_std_error sdi_mailbox_enable(sdi_resource_hdl_t resource_hdl, bool messaging_enable) {
     t_std_error rc = STD_ERR_OK;
-    uint8_t  mailbox_reg_value[SDI_COMM_DEV_MAILBOX_ENABLE_REG] = {0};
+    uint8_t  mailbox_reg_value[SDI_COMM_DEV_MAILBOX_ENABLE_REG_SIZE] = {0};
     uint16_t reg_data =0;
 
     if (messaging_enable) {

--- a/src/drivers/sdi_cpld.c
+++ b/src/drivers/sdi_cpld.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/drivers/sdi_cpld_driver.c
+++ b/src/drivers/sdi_cpld_driver.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/drivers/sdi_cpld_pin.c
+++ b/src/drivers/sdi_cpld_pin.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/drivers/sdi_cpld_pin_group.c
+++ b/src/drivers/sdi_cpld_pin_group.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/drivers/sdi_dell_eeprom.c
+++ b/src/drivers/sdi_dell_eeprom.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/drivers/sdi_eeprom.c
+++ b/src/drivers/sdi_eeprom.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/drivers/sdi_emc142x.c
+++ b/src/drivers/sdi_emc142x.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/drivers/sdi_emc2305.c
+++ b/src/drivers/sdi_emc2305.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain
@@ -606,10 +606,11 @@ static void sdi_emc2305_device_database_init(std_config_node_t cur_node,
         snprintf(emc2305_data->emc2305_fan[fan_id].alias, SDI_MAX_NAME_LEN,
                                        "emc2305-%d-%d", chip->instance, fan_id);
     } else {
-        emc2305_data->emc2305_fan[fan_id].alias = calloc(1, (strlen(node_attr)+1));
+        uint_t size = strlen(node_attr) + 1;
+        emc2305_data->emc2305_fan[fan_id].alias = calloc(1, size);
         STD_ASSERT(emc2305_data->emc2305_fan[fan_id].alias != NULL);
         safestrncpy(emc2305_data->emc2305_fan[fan_id].alias, node_attr,
-                    (strlen(node_attr)+1));
+                    size);
     }
 
     sdi_resource_add(SDI_RESOURCE_FAN, emc2305_data->emc2305_fan[fan_id].alias,

--- a/src/drivers/sdi_fixed_port.c
+++ b/src/drivers/sdi_fixed_port.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/drivers/sdi_i2cmux_pca.c
+++ b/src/drivers/sdi_i2cmux_pca.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain
@@ -119,7 +119,10 @@ static void sdi_i2cmux_pca_chan_release_bus(sdi_i2c_bus_hdl_t bus_handle)
     /* Deselect the mux (all channels) */
     SDI_DEVICE_TRACEMSG_LOG("%s:%d sending deselect on bus %s addr %02x\n",
             __FUNCTION__, __LINE__, mux->i2c_bus_name, bus->mux_i2c_addr);
-    sdi_smbus_write_byte(mux->i2c_bus, bus->mux_i2c_addr, 0, 0, 0);
+    if(STD_ERR_OK != sdi_smbus_write_byte(mux->i2c_bus, bus->mux_i2c_addr, 0, 0, 0)){
+        SDI_DEVICE_TRACEMSG_LOG("Error in in smbus write for pca channel bus release on %s",
+            mux->i2c_bus_name);
+    }
     std_mutex_unlock (&(mux->mux_lock));
 }
 

--- a/src/drivers/sdi_i2cmux_pin.c
+++ b/src/drivers/sdi_i2cmux_pin.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/drivers/sdi_ina219.c
+++ b/src/drivers/sdi_ina219.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/drivers/sdi_io_bus.c
+++ b/src/drivers/sdi_io_bus.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/drivers/sdi_max6699.c
+++ b/src/drivers/sdi_max6699.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain
@@ -414,7 +414,7 @@ static void sdi_max6699_device_database_init(std_config_node_t cur_node,
                  "max6699-%d-%d",dev_hdl->instance,sensor_id);
     } else{
         max6699_data->alias[sensor_id] = calloc((strlen(node_attr)+1),1);
-        safestrncpy(max6699_data->alias[sensor_id],node_attr,(strlen(node_attr)+1));
+        safestrncpy(max6699_data->alias[sensor_id],node_attr, SDI_MAX_NAME_LEN);
     }
 
     sdi_resource_add(SDI_RESOURCE_TEMPERATURE,max6699_data->alias[sensor_id],

--- a/src/drivers/sdi_media_ext_mod_ctrl.c
+++ b/src/drivers/sdi_media_ext_mod_ctrl.c
@@ -1,0 +1,260 @@
+/*
+ * Copyright (c) 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *  LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
+/*
+ * filename: sdi_media_ext_mod_ctrl.c
+ */
+
+
+/******************************************************************************
+ * sdi_media_ext_mod_ctrl.c
+ * Implements the R/W APIs for using media ext mod control, which is based on mailbox registers 
+ *****************************************************************************/
+
+#include "sdi_media_ext_mod_ctrl.h"
+#include "sdi_media.h"
+
+
+#define    SDI_EXT_MEM_MODULE_ACTIVE_DEV_MEM_ADDR_OFFSET   250
+#define    SDI_EXT_MEM_MODULE_REG_OFFSET_ADDR_MSB_OFFSET   251
+#define    SDI_EXT_MEM_MODULE_REG_OFFSET_ADDR_LSB_OFFSET   252
+#define    SDI_EXT_MEM_MODULE_DATA_MSB_OFFSET              253
+#define    SDI_EXT_MEM_MODULE_DATA_LSB_OFFSET              254
+#define    SDI_EXT_MEM_MODULE_CTRL_STATUS_OFFSET           255
+
+static t_std_error _sdi_sfp_read_generic (sdi_resource_hdl_t resource_hdl, sdi_media_eeprom_addr_t* addr,
+                           uint8_t *data, size_t data_len)
+{
+    sdi_device_hdl_t sfp_device = NULL;
+    sfp_device_t *sfp_priv_data = NULL;
+    t_std_error rc = STD_ERR_OK;
+    sdi_i2c_addr_t address;
+
+    int device_addr = addr->device_addr;
+    uint_t offset = addr->offset;
+
+    STD_ASSERT(data != NULL);
+    STD_ASSERT(data_len > 0);
+    STD_ASSERT(resource_hdl != NULL);
+
+
+    sfp_device = (sdi_device_hdl_t)resource_hdl;
+    address = sfp_device->addr.i2c_addr;
+    sfp_priv_data = (sfp_device_t *)sfp_device->private_data;
+    STD_ASSERT(sfp_priv_data != NULL);
+
+    if (device_addr > SDI_MEDIA_DEVICE_ADDR_AUTO) {
+        address.i2c_addr = device_addr;
+    } else if ( device_addr < SDI_MEDIA_DEVICE_ADDR_AUTO) {
+        SDI_DEVICE_ERRMSG_LOG("Invalid media device address value: %d ", device_addr);
+        return SDI_DEVICE_ERRCODE(EINVAL);
+    }
+
+    rc = sdi_smbus_read_multi_byte(sfp_device->bus_hdl, address,
+           offset, data, data_len, SDI_I2C_FLAG_NONE);
+
+    if (rc != STD_ERR_OK) {
+        SDI_DEVICE_ERRMSG_LOG("sfp smbus read failed at addr : %d reg : %d"
+                              "rc : %d", address, offset, rc);
+    }
+
+    return rc;
+}
+
+static t_std_error _sdi_sfp_write_generic (sdi_resource_hdl_t resource_hdl, sdi_media_eeprom_addr_t* addr,
+                           uint8_t *data, size_t data_len)
+{
+    sdi_device_hdl_t sfp_device = NULL;
+    sfp_device_t *sfp_priv_data = NULL;
+    t_std_error rc = STD_ERR_OK;
+    sdi_i2c_addr_t address;
+
+    int device_addr = addr->device_addr;
+    uint_t offset = addr->offset;
+
+    STD_ASSERT(data != NULL);
+    STD_ASSERT(data_len > 0);
+    STD_ASSERT(resource_hdl != NULL);
+
+
+    sfp_device = (sdi_device_hdl_t)resource_hdl;
+    address = sfp_device->addr.i2c_addr;
+    sfp_priv_data = (sfp_device_t *)sfp_device->private_data;
+    STD_ASSERT(sfp_priv_data != NULL);
+
+    if (device_addr > SDI_MEDIA_DEVICE_ADDR_AUTO) {
+        address.i2c_addr = device_addr;
+    } else if ( device_addr < SDI_MEDIA_DEVICE_ADDR_AUTO) {
+        SDI_DEVICE_ERRMSG_LOG("Invalid media device address value: %d ", device_addr);
+        return SDI_DEVICE_ERRCODE(EINVAL);
+    }
+
+    rc = sdi_smbus_write_multi_byte(sfp_device->bus_hdl, address,
+           offset, data, data_len, SDI_I2C_FLAG_NONE);
+
+    if (rc != STD_ERR_OK) {
+        SDI_DEVICE_ERRMSG_LOG("sfp smbus write failed at addr : %d reg : %d"
+                              "rc : %d", address, offset, rc);
+    }
+
+    return rc;
+}
+
+/* This performs a read or write using a set of mailbox registers; based on the following memory structure */
+/*              250 |   MMD PHY Address  |  */
+/*              251 |   Reg Offset MSB   |  */
+/*              252 |   Reg Offset LSB   |  */
+/*              253 |   16 Bit Data MSB  |  */
+/*              254 |   16 Bit Data LSB  |  */
+/*              255 |   Ctrl/Status Bits |  {Bit[1:0] Oper: 
+                                                Read: 1, Write: 2},
+                                            {Bit[3:2] Status:
+                                                Idle: 0, Done: 1, Error: 2} */
+/*  A write is done by setting the desired registers, adding the data to be written, and then setting the write flag.
+    Afterwards, the status is polled every STATUS_POLL_INTERVAL_MS, either until the 'Done' flag is set or STATUS_POLL_MAX_TIMEOUT_MS is elapsed
+    A read is similar, except that the data field is initially unset, until after the 'Done' flag indicates that data is ready to be read */
+
+static t_std_error perform_oper (sdi_resource_hdl_t resource_hdl, ext_mem_addr_t mem_addr,
+                uint16_t reg_offset, uint16_t* data_buf_be, ext_mem_oper_t oper){
+
+    bool oper_set_success            = false;
+    uint8_t set_buf[EXT_MEM_SIZE]    = {0};
+    uint8_t status                   = 0;
+    uint8_t buf_read[DATA_BUF_SIZE]  = {0};
+    t_std_error rc                   = STD_ERR_OK;
+    sdi_device_hdl_t device          = NULL;
+    uint_t status_poll_timeout       = 0;
+
+    sdi_media_eeprom_addr_t addr = {
+                                    .device_addr = SDI_MEDIA_DEVICE_ADDR_A2,
+                                    .page        = SDI_MEDIA_PAGE_SELECT_NOT_SUPPORTED,
+                                    .offset      = SDI_EXT_MEM_MODULE_ACTIVE_DEV_MEM_ADDR_OFFSET
+                                   };
+
+    t_std_error (*read_generic)(sdi_resource_hdl_t, sdi_media_eeprom_addr_t *, uint8_t *, size_t) = NULL;
+    t_std_error (*write_generic)(sdi_resource_hdl_t, sdi_media_eeprom_addr_t *, uint8_t *, size_t) = NULL;
+
+
+    STD_ASSERT(resource_hdl != NULL);
+    STD_ASSERT(data_buf_be != NULL);
+
+    device = (sdi_device_hdl_t)resource_hdl;
+
+    /* Will be extended when adding QSFPx support */
+    read_generic = &_sdi_sfp_read_generic;
+    write_generic = &_sdi_sfp_write_generic;
+
+    /* Setup the buffer to be sent */
+    set_buf[0] = mem_addr;
+    set_buf[1] = (uint8_t)(reg_offset >> 8);
+    set_buf[2] = (uint8_t)(reg_offset);
+
+    /* Only set the data portion if this is a write oper */
+    if (oper == MEM_WRITE){
+        set_buf[3] = (uint8_t)((*data_buf_be) >> 8);
+        set_buf[4] = (uint8_t)(*data_buf_be);
+    }
+
+    /* Setup the operation (READ or WRITE) byte */
+    set_buf[5] = (uint8_t)(OPER_MASK & oper);
+
+    /* Set bytes that indicate the operation to be performed */
+    rc = write_generic(resource_hdl, &addr, set_buf, sizeof(set_buf)/sizeof(set_buf[0]));
+    if (rc != STD_ERR_OK){
+        SDI_DEVICE_ERRMSG_LOG("Write error on module %s when using ext mod ctrl", device->alias);
+        return rc;
+    }
+
+    addr.offset = SDI_EXT_MEM_MODULE_CTRL_STATUS_OFFSET;
+    /* Now poll the status bits to see if write oper completed  */
+    while (status_poll_timeout < STATUS_POLL_MAX_TIMEOUT_MS){
+        /* Read the status */
+        rc = read_generic(resource_hdl, &addr, &status, 1);
+        if (rc != STD_ERR_OK){
+            SDI_DEVICE_ERRMSG_LOG("Read error %u on module %s when using ext mod ctrl", rc, device->alias);
+            return rc;
+        }
+
+        switch ((status & STATUS_OPER_COMPLETE_BITMASK) >> 2){
+            /* Idle */
+            case STATUS_POLL_IDLE_STATE:
+                oper_set_success = false;
+                break;
+            /* Done */
+            case STATUS_POLL_COMPLETE_STATE:
+                oper_set_success = true;
+                break;
+            /* Error */
+            case STATUS_POLL_ERROR_STATE:
+            default:
+                oper_set_success = false;
+                SDI_DEVICE_ERRMSG_LOG("Error state on module %s when using ext mod ctrl", device->alias);
+                break;
+        }
+        if (oper_set_success){
+            break;
+        }
+        std_usleep(STATUS_POLL_INTERVAL_MS);
+        status_poll_timeout += STATUS_POLL_INTERVAL_MS;
+    }
+    if (!oper_set_success){
+        SDI_DEVICE_ERRMSG_LOG("Write did not complete on module %s when using ext mod ctrl", device->alias);
+        return rc;
+    }
+
+    /* All done */
+    if (oper == MEM_WRITE){
+        return rc;
+    }
+
+    /* Reg setup complete. Now poll data bytes */
+    addr.offset = SDI_EXT_MEM_MODULE_DATA_MSB_OFFSET;
+    rc = read_generic(resource_hdl, &addr, buf_read, sizeof(buf_read)/sizeof(buf_read[0]));
+    if (rc != STD_ERR_OK){
+        SDI_DEVICE_ERRMSG_LOG("Read error on module %s when using ext mem io", device->alias);
+        return rc;
+    }
+    /* Return as uint16_t,  two bytes as big endian */
+    *data_buf_be = (buf_read[0] << 8) | (buf_read[1]);
+    return rc;
+}
+
+
+/* Typically, multiple operations are needed to perform a certain task. This API allows one perform a chain of R/W operations */
+t_std_error sdi_media_ext_mod_ctrl_chain_oper (sdi_resource_hdl_t resource_hdl, ext_dev_ctrl_oper_packet_t* packets, size_t num_packets){
+
+    sdi_device_hdl_t device = NULL;
+    t_std_error rc          = STD_ERR_OK;
+    size_t count            = 0;
+
+    STD_ASSERT(resource_hdl != NULL);
+    STD_ASSERT(packets != NULL);
+
+    device = (sdi_device_hdl_t)resource_hdl;
+
+    for (count = 0; count < num_packets; count++){
+
+        rc = perform_oper (resource_hdl, packets[count].mem_addr, packets[count].reg_offset, &(packets[count].data_buf_big_endian),
+                            packets[count].oper);
+        if (rc != STD_ERR_OK){
+            SDI_DEVICE_ERRMSG_LOG("Ext mod ctrl oper failure (rc: %u) at packet %d on module %s", rc, count, device->alias);
+            break;
+        }
+    }
+
+    return rc;
+}
+

--- a/src/drivers/sdi_media_phy_mgmt.c
+++ b/src/drivers/sdi_media_phy_mgmt.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain
@@ -31,7 +31,8 @@
 #include "std_assert.h"
 #include "std_time_tools.h"
 #include "sdi_platform_util.h"
-
+#include "sdi_sfp_plus_aq.h"
+ 
 /* Magic number description not given in appnote from Marvell
    an-2036 app note from Mavell give below magic value to enable
    SGMII mode for phy device */
@@ -375,4 +376,32 @@ t_std_error sdi_cusfp_phy_serdes_control (sdi_device_hdl_t sfp_device, bool enab
     } while (0);
 
     return rc;
+}
+
+t_std_error sdi_cusfp_plus_phy_serdes_control (sdi_device_hdl_t sfp_device, bool enable)
+{
+    STD_ASSERT(sfp_device != NULL);
+
+    return sdi_media_aq_set_tx_state((sdi_resource_hdl_t)sfp_device, enable);
+}
+
+t_std_error sdi_cusfp_plus_phy_link_status_get (sdi_device_hdl_t sfp_device, bool* status)
+{
+    STD_ASSERT(sfp_device != NULL);
+
+    return sdi_media_aq_get_link_status((sdi_resource_hdl_t)sfp_device, status);
+}
+
+t_std_error sdi_cusfp_plus_phy_speed_set(sdi_device_hdl_t sfp_device, sdi_media_speed_t speed)
+{
+    STD_ASSERT(sfp_device != NULL);
+    return sdi_media_aq_set_rate((sdi_resource_hdl_t)sfp_device, speed);
+}
+
+t_std_error sdi_cusfp_plus_phy_speed_get(sdi_device_hdl_t sfp_device, sdi_media_speed_t* speed)
+{
+    bool link_status = false;
+ 
+    STD_ASSERT(sfp_device != NULL);
+    return sdi_media_aq_get_line_side_status((sdi_resource_hdl_t)sfp_device, &link_status, speed);
 }

--- a/src/drivers/sdi_mono_color_pin_led.c
+++ b/src/drivers/sdi_mono_color_pin_led.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/drivers/sdi_nvram.c
+++ b/src/drivers/sdi_nvram.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/drivers/sdi_onie_eeprom.c
+++ b/src/drivers/sdi_onie_eeprom.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain
@@ -39,6 +39,12 @@
 #include <ctype.h>
 #include <zlib.h>
 
+static char system_part_number[SDI_PART_NUM_LEN]={'\0'};
+
+void sdi_sys_part_number_get(char *part_num)
+{
+    safestrncpy(part_num, system_part_number, SDI_PART_NUM_LEN);
+}
 
 static void copy_bytes_to_string(char *dst, size_t dst_size, const char *src, size_t src_size)
 {
@@ -226,7 +232,7 @@ static void sdi_onie_fill_vendor_extn(sdi_onie_tlv_field *tlv_fld,
                 entity_data->air_flow            = SDI_PWR_AIR_FLOW_REVERSE;
                 break;
             default:
-                err_mesg = "Invalid value for PSU type in ONIE EEPROM vendor extension";
+                err_mesg = "Invlaid value for PSU type in ONIE EEPROM vendor extension";
             }
             break;
 
@@ -371,6 +377,7 @@ static void sdi_onie_fill_tlv_entity_info(char *eeprom_buf, sdi_entity_parser_t 
 
         case SDI_ONIE_PART_NO_TAG:
             COPY_BYTES_TO_STRING(entity_data->part_number, (const char *) tlv_fld->value, (size_t) tlv_fld->length);
+            safestrncpy(system_part_number, entity_data->part_number, SDI_PART_NUM_LEN);
             break;
 
         default:

--- a/src/drivers/sdi_pmbus_dev.c
+++ b/src/drivers/sdi_pmbus_dev.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain
@@ -562,7 +562,7 @@ static void sdi_pmbus_resource_add(sdi_pmbus_dev_t  *pmbus_dev )
 {
     uint_t sensor_index = 0;
     void *callback_fns = NULL;
-    char alias[SDI_MAX_NAME_LEN] = {0};
+    char alias[SDI_MAX_NAME_LEN*2] = {0};
     int resource_type = -1;
 
     for(sensor_index = 0;sensor_index < pmbus_dev->max_sensors;sensor_index++)
@@ -584,7 +584,7 @@ static void sdi_pmbus_resource_add(sdi_pmbus_dev_t  *pmbus_dev )
             continue;
         }
 
-         snprintf(alias,SDI_MAX_NAME_LEN,"psu-%d-%s",
+         snprintf(alias,sizeof(alias),"psu-%d-%s",
                   pmbus_dev->dev->instance,
                   pmbus_dev->sdi_pmbus_sensors[sensor_index].alias);
 

--- a/src/drivers/sdi_pseudo_bus.c
+++ b/src/drivers/sdi_pseudo_bus.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/drivers/sdi_qsfp.c
+++ b/src/drivers/sdi_qsfp.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/drivers/sdi_qsfp28_dd.c
+++ b/src/drivers/sdi_qsfp28_dd.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/drivers/sdi_qsfp28_dd_eeprom.c
+++ b/src/drivers/sdi_qsfp28_dd_eeprom.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/drivers/sdi_qsfp_4X1_1000baseT.c
+++ b/src/drivers/sdi_qsfp_4X1_1000baseT.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/drivers/sdi_s6k_psu.c
+++ b/src/drivers/sdi_s6k_psu.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/drivers/sdi_segment_display.c
+++ b/src/drivers/sdi_segment_display.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/drivers/sdi_seven_segment_pin_led.c
+++ b/src/drivers/sdi_seven_segment_pin_led.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/drivers/sdi_sf_entity_info.c
+++ b/src/drivers/sdi_sf_entity_info.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain
@@ -137,7 +137,8 @@ static void construct_date_code(char* date_str /*Of the form YYMMDD*/)
 
     uint_t tmp = strlen(date_str);
     char tmp_str[tmp + 1];
-    safestrncpy(tmp_str, date_str, tmp + 1);
+    memcpy(tmp_str, date_str, sizeof(tmp_str));
+    tmp_str[tmp] = '\0';
     date_str[3] = '\0';
 
     /* Get day and convert */
@@ -202,7 +203,7 @@ t_std_error sdi_sf_entity_info_data_get(void *resource_hdl,
                          eeprom_data->country_code_end_addr, ptr, country_code_len);
         ptr += country_code_len;
 
-        safestrncpy(ptr, entity_info->part_number, strlen(entity_info->part_number)+1);
+        memcpy(ptr, entity_info->part_number, strlen(entity_info->part_number));
         ptr += strlen(entity_info->part_number);
 
         entity_info_populate(chip, eeprom_data->mfg_id_start_addr,
@@ -353,9 +354,11 @@ static t_std_error sdi_sf_entity_info_register(std_config_node_t node,
             break;
         case 1:
             SDI_DEVICE_ERRMSG_LOG("PPID end address unset in device smf config file");
+            free(chip);
             return STD_ERR(BOARD, FAIL, ppid_address_count);
         case 2:
             SDI_DEVICE_ERRMSG_LOG("PPID start address unset in device smf config file");
+            free(chip);
             return STD_ERR(BOARD, FAIL, ppid_address_count);
         case 3:
         default:

--- a/src/drivers/sdi_sf_fan.c
+++ b/src/drivers/sdi_sf_fan.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/drivers/sdi_sf_io_bus.c
+++ b/src/drivers/sdi_sf_io_bus.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/drivers/sdi_sf_tmp.c
+++ b/src/drivers/sdi_sf_tmp.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/drivers/sdi_sfp.c
+++ b/src/drivers/sdi_sfp.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/drivers/sdi_sfp_plus_aq.c
+++ b/src/drivers/sdi_sfp_plus_aq.c
@@ -1,0 +1,382 @@
+/*
+ * Copyright (c) 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ *  LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
+/*
+ * filename: sdi_sfp_plus_aq.c
+ */
+
+
+/******************************************************************************
+ * sdi_sfp_plus_aq.c
+ * Implements the SFP+ APIs for using Aquantia 10G BASE T media, based on ext mod control 
+ *****************************************************************************/
+
+/* This uses the extended module control for implementing basic features of Aquantia's 10G BASE T module */
+
+#include "sdi_media_ext_mod_ctrl.h"
+#include "sdi_sfp_plus_aq.h"
+
+
+#define ARR_SIZE(x)                   (sizeof(x))/(sizeof(x[0]))
+
+
+#define AQ_TX_STATE_SET_BITMASK       1
+#define AQ_SYS_STATUS_IF_RX_BITMASK       (1 << 0x0D)
+#define AQ_SYS_STATUS_IF_TX_BITMASK       (1 << 0x0C)
+#define AQ_SYS_STATUS_IF_SPEED_BITMASK    (0x0F << 0x08)
+#define AQ_SYS_STATUS_IF_SPEED_GET(x) ((AQ_SYS_STATUS_IF_SPEED_BITMASK & (x)) >> 0x08)
+
+#define AQ_LINK_STATE_BITMASK         0x01
+#define AQ_LINE_SIDE_LINK_RATE_ADDR   0x07
+#define AQ_LINE_SIDE_SPEED_BITMASK    (7<<1)
+#define AQ_LINE_SIDE_SPEED_GET(x)     ((AQ_LINE_SIDE_SPEED_BITMASK & (x)) >>  0x01)
+
+#define AQ_SPEED_SET_SERDES_ON_DELAY_US   (800 * 1000)
+
+/* Set of operations needed to set certain speeds */
+/* This 10g actually advertises all other rates */
+/*static ext_dev_ctrl_oper_packet_t aq_10g_multigig_rate_set_packets[] =
+        {{mem_addr: AQ_RATE_SET_MEM_ADDR, reg_offset: 0x0000, data_buf_big_endian: 0x2000, oper: MEM_WRITE},
+        {mem_addr: AQ_RATE_SET_MEM_ADDR, reg_offset: 0x0010, data_buf_big_endian: 0x9101, oper: MEM_WRITE},
+        {mem_addr: AQ_RATE_SET_MEM_ADDR, reg_offset: 0xC400, data_buf_big_endian: 0x9C40, oper: MEM_WRITE},
+        {mem_addr: AQ_RATE_SET_MEM_ADDR, reg_offset: 0x0020, data_buf_big_endian: 0x00A1, oper: MEM_WRITE},
+        {mem_addr: AQ_RATE_SET_MEM_ADDR, reg_offset: 0x0000, data_buf_big_endian: 0x3000, oper: MEM_WRITE}};
+*/
+/* Advertise 10g only: Ideally, this should never be used because we want the far end to be aware of other speeds, however link flap issues are seen when using 10g mutirate (aq_10g_multigig_rate_set_packets) */
+static ext_dev_ctrl_oper_packet_t aq_10g_rate_set_packets[] =
+        {{mem_addr: AQ_RATE_SET_MEM_ADDR, reg_offset: 0x0000, data_buf_big_endian: 0x2000, oper: MEM_WRITE},
+        {mem_addr: AQ_RATE_SET_MEM_ADDR, reg_offset: 0x0010, data_buf_big_endian: 0x9001, oper: MEM_WRITE},
+        {mem_addr: AQ_RATE_SET_MEM_ADDR, reg_offset: 0xC400, data_buf_big_endian: 0x0040, oper: MEM_WRITE},
+        {mem_addr: AQ_RATE_SET_MEM_ADDR, reg_offset: 0x0020, data_buf_big_endian: 0x1001, oper: MEM_WRITE},
+        {mem_addr: AQ_RATE_SET_MEM_ADDR, reg_offset: 0x0000, data_buf_big_endian: 0x3000, oper: MEM_WRITE}};
+
+/* Advertise 1g only*/
+static ext_dev_ctrl_oper_packet_t aq_1g_rate_set_packets[] =
+        {{mem_addr: AQ_RATE_SET_MEM_ADDR, reg_offset: 0x0000, data_buf_big_endian: 0x2000, oper: MEM_WRITE},
+        {mem_addr: AQ_RATE_SET_MEM_ADDR, reg_offset: 0x0010, data_buf_big_endian: 0x8001, oper: MEM_WRITE},
+        {mem_addr: AQ_RATE_SET_MEM_ADDR, reg_offset: 0xC400, data_buf_big_endian: 0x8040, oper: MEM_WRITE},
+        {mem_addr: AQ_RATE_SET_MEM_ADDR, reg_offset: 0x0020, data_buf_big_endian: 0x0001, oper: MEM_WRITE},
+        {mem_addr: AQ_RATE_SET_MEM_ADDR, reg_offset: 0x0000, data_buf_big_endian: 0x3000, oper: MEM_WRITE}};
+
+/* Advertise 100m only*/
+static ext_dev_ctrl_oper_packet_t aq_100m_rate_set_packets[] =
+        {{mem_addr: AQ_RATE_SET_MEM_ADDR, reg_offset: 0x0000, data_buf_big_endian: 0x2000, oper: MEM_WRITE},
+        {mem_addr: AQ_RATE_SET_MEM_ADDR, reg_offset: 0x0010, data_buf_big_endian: 0x0101, oper: MEM_WRITE},
+        {mem_addr: AQ_RATE_SET_MEM_ADDR, reg_offset: 0xC400, data_buf_big_endian: 0x0040, oper: MEM_WRITE},
+        {mem_addr: AQ_RATE_SET_MEM_ADDR, reg_offset: 0x0020, data_buf_big_endian: 0x0001, oper: MEM_WRITE},
+        {mem_addr: AQ_RATE_SET_MEM_ADDR, reg_offset: 0x0000, data_buf_big_endian: 0x3000, oper: MEM_WRITE}};
+
+/* Advertise 2.5g only*/
+static ext_dev_ctrl_oper_packet_t aq_2500m_rate_set_packets[] =
+        {{mem_addr: AQ_RATE_SET_MEM_ADDR, reg_offset: 0x0000, data_buf_big_endian: 0x2000, oper: MEM_WRITE},
+        {mem_addr: AQ_RATE_SET_MEM_ADDR, reg_offset: 0x0010, data_buf_big_endian: 0x9001, oper: MEM_WRITE},
+        {mem_addr: AQ_RATE_SET_MEM_ADDR, reg_offset: 0xC400, data_buf_big_endian: 0x0040, oper: MEM_WRITE},
+        {mem_addr: AQ_RATE_SET_MEM_ADDR, reg_offset: 0x0020, data_buf_big_endian: 0x00A1, oper: MEM_WRITE},
+        {mem_addr: AQ_RATE_SET_MEM_ADDR, reg_offset: 0x0000, data_buf_big_endian: 0x3000, oper: MEM_WRITE}};
+
+/* Advertise 5g only*/
+static ext_dev_ctrl_oper_packet_t aq_5g_rate_set_packets[] =
+        {{mem_addr: AQ_RATE_SET_MEM_ADDR, reg_offset: 0x0000, data_buf_big_endian: 0x2000, oper: MEM_WRITE},
+        {mem_addr: AQ_RATE_SET_MEM_ADDR, reg_offset: 0x0010, data_buf_big_endian: 0x9001, oper: MEM_WRITE},
+        {mem_addr: AQ_RATE_SET_MEM_ADDR, reg_offset: 0xC400, data_buf_big_endian: 0x0040, oper: MEM_WRITE},
+        {mem_addr: AQ_RATE_SET_MEM_ADDR, reg_offset: 0x0020, data_buf_big_endian: 0x0141, oper: MEM_WRITE},
+        {mem_addr: AQ_RATE_SET_MEM_ADDR, reg_offset: 0x0000, data_buf_big_endian: 0x3000, oper: MEM_WRITE}};
+
+t_std_error sdi_media_aq_set_tx_state (sdi_resource_hdl_t resource_hdl, bool state);
+t_std_error sdi_media_aq_get_line_side_status (sdi_resource_hdl_t resource_hdl, bool *link_status, sdi_media_speed_t *link_speed_rate);
+
+/* This is for setting lineside speed */
+t_std_error sdi_media_aq_set_rate (sdi_resource_hdl_t resource_hdl, sdi_media_speed_t rate)
+{
+    t_std_error rc          = STD_ERR_OK;
+    sdi_device_hdl_t device = NULL;
+    bool link_stat = false;
+    bool serdes_stat = false;
+    sdi_media_speed_t curr_speed = SDI_MEDIA_INVALID_SPEED;
+    ext_dev_ctrl_oper_packet_t* packets = NULL;
+    size_t size = 0;
+
+    STD_ASSERT(resource_hdl != NULL);
+    device = (sdi_device_hdl_t)resource_hdl;
+
+    rc = sdi_media_aq_get_line_side_status(resource_hdl, &link_stat, &curr_speed);
+    if (rc != STD_ERR_OK){
+        SDI_DEVICE_ERRMSG_LOG("AQ: Error %u when checking current speed and link status, while attempting speed set on module %s", rc, device->alias);
+        return rc;
+    }
+
+    if (curr_speed ==  rate){
+        /* Nothing to do */
+        return rc;
+    }
+
+    rc = sdi_media_aq_get_tx_state(resource_hdl, &serdes_stat);
+    if (rc != STD_ERR_OK){
+        SDI_DEVICE_ERRMSG_LOG("AQ: Error %u when checking serdes status, while attempting speed set on module %s", rc, device->alias);
+        return rc;
+    }
+
+
+    /* Before manipulating speed, turn off serdes */
+    /* Will restore state later */
+    rc = sdi_media_aq_set_tx_state(resource_hdl, false);
+    if (rc != STD_ERR_OK){
+        SDI_DEVICE_ERRMSG_LOG("AQ: Error %u when turning off serdes when attempting speed set on module %s", rc, device->alias);
+        return rc;
+    }
+
+    /* Sleep to allow cfg to settle*/
+    std_usleep(AQ_SPEED_SET_SERDES_ON_DELAY_US);
+
+    switch (rate){
+        case SDI_MEDIA_SPEED_100M:
+            packets = aq_100m_rate_set_packets;
+            size = ARR_SIZE(aq_100m_rate_set_packets);
+            break;
+        case SDI_MEDIA_SPEED_1G:
+            packets = aq_1g_rate_set_packets;
+            size = ARR_SIZE(aq_1g_rate_set_packets);
+            break;
+        case SDI_MEDIA_SPEED_2500M:
+            packets = aq_2500m_rate_set_packets;
+            size = ARR_SIZE(aq_2500m_rate_set_packets);
+            break;
+        case SDI_MEDIA_SPEED_5G:
+            packets = aq_5g_rate_set_packets;
+            size = ARR_SIZE(aq_5g_rate_set_packets);
+            break;
+        case SDI_MEDIA_SPEED_10G:
+        default:
+            packets = aq_10g_rate_set_packets;
+            size = ARR_SIZE(aq_10g_rate_set_packets);
+            break;
+    }
+
+    rc = sdi_media_ext_mod_ctrl_chain_oper(resource_hdl, packets, size);
+    if (rc != STD_ERR_OK){
+        SDI_DEVICE_ERRMSG_LOG("AQ: Could not set rate on Aquantia media on module %s", device->alias);
+        return rc;
+    }
+    std_usleep(AQ_SPEED_SET_SERDES_ON_DELAY_US);
+
+    /* Wait a bit and then turn serdes on if it was previously on */
+    if (serdes_stat){
+        rc = sdi_media_aq_set_tx_state(resource_hdl, true);
+        if (rc != STD_ERR_OK){
+            SDI_DEVICE_ERRMSG_LOG("AQ: Error %u when turning on serdes after speed set on module %s", rc, device->alias);
+        }
+    }
+    return rc;
+}
+/* This gets the system (NPU) side status. Note that there may be a disparity between lineside and system side  */
+t_std_error sdi_media_aq_get_system_side_status (sdi_resource_hdl_t resource_hdl, bool *rx_if_link_status, bool *tx_if_link_status,
+                    sdi_media_speed_t *if_speed_rate)
+{
+    sdi_device_hdl_t device = NULL;
+    t_std_error rc          = STD_ERR_OK;
+
+    STD_ASSERT(resource_hdl != NULL);
+    STD_ASSERT(rx_if_link_status != NULL);
+    STD_ASSERT(tx_if_link_status != NULL);
+    STD_ASSERT(if_speed_rate != NULL);
+
+    device = (sdi_device_hdl_t)resource_hdl;
+
+    *if_speed_rate = SDI_MEDIA_INVALID_SPEED;
+    ext_dev_ctrl_oper_packet_t status_packet = {mem_addr: AQ_SYS_STATUS_GET_ADDR, reg_offset: 0xE812, data_buf_big_endian: 0, oper: MEM_READ};
+
+    rc = sdi_media_ext_mod_ctrl_chain_oper(resource_hdl, &status_packet, 1);
+
+    if (rc != STD_ERR_OK){
+        SDI_DEVICE_ERRMSG_LOG("AQ: System side status poll failed for module %s", device->alias);
+        return rc;
+    }
+    *rx_if_link_status = (bool)(AQ_SYS_STATUS_IF_RX_BITMASK & status_packet.data_buf_big_endian);
+    *tx_if_link_status = (bool)(AQ_SYS_STATUS_IF_TX_BITMASK & status_packet.data_buf_big_endian);
+
+    switch (AQ_SYS_STATUS_IF_SPEED_GET(status_packet.data_buf_big_endian)){
+        case 0x01:
+            *if_speed_rate = SDI_MEDIA_SPEED_100M;
+            break;
+        case 0x02:
+            *if_speed_rate = SDI_MEDIA_SPEED_1G;
+            break;
+        case 0x03:
+            *if_speed_rate = SDI_MEDIA_SPEED_10G;
+            break;
+        case 0x04:
+            *if_speed_rate = SDI_MEDIA_SPEED_2500M;
+            break;
+        case 0x05:
+            *if_speed_rate = SDI_MEDIA_SPEED_5G;
+            break;
+        case 0x00:
+            /* No speed */
+            break;
+        default:
+            rc = ~STD_ERR_OK;
+            SDI_DEVICE_ERRMSG_LOG("AQ: Found unknown system-side speed on module %s", device->alias);
+            break;
+    }
+    return rc;
+}
+
+/* To set the tx state (which is inverted), only one bit needs to be set. However this bit is in a byte that contains other info that must not be changed */
+/* Hence a read-modify-write is used to set the tx state bit */
+t_std_error sdi_media_aq_set_tx_state (sdi_resource_hdl_t resource_hdl, bool state)
+{
+
+    sdi_device_hdl_t device = NULL;
+    t_std_error rc          = STD_ERR_OK;
+    ext_dev_ctrl_oper_packet_t tx_state_packet = {mem_addr: AQ_TX_STATE_SET_ADDR, reg_offset: 0x0009, data_buf_big_endian: 0, oper: MEM_READ};
+
+    STD_ASSERT(resource_hdl != NULL);
+
+    device = (sdi_device_hdl_t)resource_hdl;
+
+    /* Read */
+    rc = sdi_media_ext_mod_ctrl_chain_oper(resource_hdl, &tx_state_packet, 1);
+    if (rc != STD_ERR_OK){
+        SDI_DEVICE_ERRMSG_LOG("AQ: Error %u while reading tx state module %s", rc, device->alias);
+        return rc;
+    }
+    /* Modify */
+    /* TX state control is inverted */
+    state ? (tx_state_packet.data_buf_big_endian &= ~AQ_TX_STATE_SET_BITMASK) : (tx_state_packet.data_buf_big_endian |= AQ_TX_STATE_SET_BITMASK);
+
+    /* Write */
+    tx_state_packet.oper = MEM_WRITE;
+    rc = sdi_media_ext_mod_ctrl_chain_oper(resource_hdl, &tx_state_packet, 1);
+
+    if (rc != STD_ERR_OK){
+        SDI_DEVICE_ERRMSG_LOG("AQ: Failed to set tx state to %d for module %s", state, device->alias);
+    }
+    return rc;
+}
+
+/* Same location used in sdi_media_aq_set_tx_state; except operation is a read */
+t_std_error sdi_media_aq_get_tx_state (sdi_resource_hdl_t resource_hdl, bool *state)
+{
+
+    sdi_device_hdl_t device = NULL;
+    t_std_error rc          = STD_ERR_OK;
+
+    STD_ASSERT(resource_hdl != NULL);
+    STD_ASSERT(state != NULL);
+
+    device = (sdi_device_hdl_t)resource_hdl;
+    ext_dev_ctrl_oper_packet_t tx_state_packet = {mem_addr: AQ_TX_STATE_SET_ADDR, reg_offset: 0x0009, data_buf_big_endian: 0x0000, oper: MEM_READ};
+
+    rc = sdi_media_ext_mod_ctrl_chain_oper(resource_hdl, &tx_state_packet, 1);
+
+    if (rc != STD_ERR_OK){
+        SDI_DEVICE_ERRMSG_LOG("AQ: Failed to get tx state for module %s", device->alias);
+    } else {
+        /* TX state in inverted */
+        *state = !((bool)(tx_state_packet.data_buf_big_endian & AQ_TX_STATE_SET_BITMASK));
+    }
+    return rc;
+}
+
+/* This gets the lineside status, which includes lineside speed and link status. Both are at different locations */
+t_std_error sdi_media_aq_get_line_side_status (sdi_resource_hdl_t resource_hdl, bool *link_status, sdi_media_speed_t *link_speed_rate)
+{
+    sdi_device_hdl_t device = NULL;
+    t_std_error rc          = STD_ERR_OK;
+    ext_dev_ctrl_oper_packet_t link_state_packet = {mem_addr: AQ_CURR_LINK_STATE_ADDR, reg_offset: 0xE800, data_buf_big_endian: 0, oper: MEM_READ};
+
+    STD_ASSERT(resource_hdl != NULL);
+    STD_ASSERT(link_status != NULL);
+    STD_ASSERT(link_speed_rate != NULL);
+
+    device = (sdi_device_hdl_t)resource_hdl;
+    *link_speed_rate = SDI_MEDIA_INVALID_SPEED;
+    rc = sdi_media_ext_mod_ctrl_chain_oper(resource_hdl, &link_state_packet, 1);
+    if (rc != STD_ERR_OK){
+        SDI_DEVICE_ERRMSG_LOG("Error while reading lineside link status on module %s", device->alias);
+        return rc;
+    }
+    *link_status = (bool)(link_state_packet.data_buf_big_endian & AQ_LINK_STATE_BITMASK);
+
+    link_state_packet.mem_addr = AQ_LINE_SIDE_LINK_RATE_ADDR;
+    link_state_packet.reg_offset = 0xC800;
+
+    rc = sdi_media_ext_mod_ctrl_chain_oper(resource_hdl, &link_state_packet, 1);
+    if (rc != STD_ERR_OK){
+        SDI_DEVICE_ERRMSG_LOG("Error while reading lineside link speed on module %s", device->alias);
+        return rc;
+    }
+
+    switch (AQ_LINE_SIDE_SPEED_GET(link_state_packet.data_buf_big_endian)){
+        case 0x01:
+            *link_speed_rate = SDI_MEDIA_SPEED_100M;
+            break;
+        case 0x02:
+            *link_speed_rate = SDI_MEDIA_SPEED_1G;
+            break;
+        case 0x03:
+            *link_speed_rate = SDI_MEDIA_SPEED_10G;
+            break;
+        case 0x04:
+            *link_speed_rate = SDI_MEDIA_SPEED_2500M;
+            break;
+        case 0x05:
+            *link_speed_rate = SDI_MEDIA_SPEED_5G;
+            break;
+        case 0x00:
+            /* No speed */
+            break;
+        default:
+            rc = ~STD_ERR_OK;
+            SDI_DEVICE_ERRMSG_LOG("AQ: Found unknown line-side speed on module %s", device->alias);
+            break;
+    }
+    return rc;
+}
+
+/* This gets the overall link status */
+t_std_error sdi_media_aq_get_link_status(sdi_resource_hdl_t resource_hdl, bool* status)
+{
+    sdi_device_hdl_t device = NULL;
+    t_std_error rc          = STD_ERR_OK;
+    bool link_status_ls = false, link_status_ss_tx = false, link_status_ss_rx = false;
+    sdi_media_speed_t speed_ls = SDI_MEDIA_INVALID_SPEED, speed_ss = SDI_MEDIA_INVALID_SPEED;
+
+    STD_ASSERT(resource_hdl != NULL);
+    STD_ASSERT(status != NULL);
+
+    device = (sdi_device_hdl_t)resource_hdl;
+    /* For link to really be up, lineside and system side links need to be up, and speeds must match */
+
+    rc = sdi_media_aq_get_line_side_status(resource_hdl, &link_status_ls, &speed_ls);
+    if (rc != STD_ERR_OK){
+        SDI_DEVICE_ERRMSG_LOG("AQ: lineside status read failed for module %s",  device->alias);
+        *status = false;
+        return rc;
+    }
+
+    rc = sdi_media_aq_get_system_side_status(resource_hdl, &link_status_ss_rx, &link_status_ss_tx, &speed_ss);
+    if (rc != STD_ERR_OK){
+        SDI_DEVICE_ERRMSG_LOG("AQ: system side status read failed for module %s",  device->alias);
+        *status = false;
+        return rc;
+    }
+
+    *status = (speed_ls == speed_ss) && (link_status_ss_tx && link_status_ss_rx && link_status_ls);
+
+    return rc;
+}
+

--- a/src/drivers/sdi_tmp75.c
+++ b/src/drivers/sdi_tmp75.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/drivers/sys-interface-drivers/sdi_gpio.c
+++ b/src/drivers/sys-interface-drivers/sdi_gpio.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain
@@ -733,11 +733,10 @@ static t_std_error set_gpio_group_default_configuration(
 static void create_gpio_group(sdi_gpio_group_t *gpio_group,
                              const char *pin_group_str)
 {
-    char delimiter = ',';
     size_t count = 0;
     const char *token = NULL;
     std_parsed_string_t handle;
-    if (std_parse_string(&handle, pin_group_str, &delimiter)) {
+    if (std_parse_string(&handle, pin_group_str, ",")) {
         count = std_parse_string_num_tokens(handle);
         STD_ASSERT(count >= MIN_NUMBER_OF_PINS_IN_GROUP);
         STD_ASSERT(gpio_group != NULL);

--- a/src/drivers/sys-interface-drivers/sdi_i2cdev.c
+++ b/src/drivers/sys-interface-drivers/sdi_i2cdev.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain
@@ -155,7 +155,7 @@ static t_std_error sdi_get_i2c_device_path_by_sysfs_name(const char *bus_name,
     char *sptr = NULL;
     char *str = NULL;
     char i2cdev[PATH_MAX] = {0};
-    char name[PATH_MAX] = {0};
+    char name[PATH_MAX*2] = {0};
     t_std_error rc = SDI_DEVICE_ERR_PARAM;
 
     snprintf(i2cdev, PATH_MAX, "%s/class/i2c-dev", SYSFS_PATH);
@@ -177,7 +177,7 @@ static t_std_error sdi_get_i2c_device_path_by_sysfs_name(const char *bus_name,
             continue;
         }
 
-        snprintf(name, PATH_MAX, "%s/%s/device/name", i2cdev, ent->d_name);
+        snprintf(name, sizeof(name), "%s/%s/device/name", i2cdev, ent->d_name);
         if ((fp = fopen(name, "r")) == NULL) {
             rc = SDI_DEVICE_ERRNO;
             SDI_DEVICE_ERRNO_LOG();
@@ -891,10 +891,10 @@ static t_std_error sdi_i2cdev_driver_register(std_config_node_t node,
 
     str = std_config_attr_get(node, SDI_DEV_ATTR_BUS_NAME);
     if (str == NULL) {
-            snprintf(i2c_bus->bus.bus_name, SDI_MAX_NAME_LEN, "%s-%d",
+        snprintf(i2c_bus->bus.bus_name, SDI_MAX_NAME_LEN, "%s-%d",
                 std_config_name_get(node), i2c_bus->bus.bus_id);
     } else {
-            safestrncpy(i2c_bus->bus.bus_name, str, SDI_MAX_NAME_LEN);
+        safestrncpy(i2c_bus->bus.bus_name, str, SDI_MAX_NAME_LEN);
     }
 
     i2c_bus->ops = &sdi_i2cdev_bus_ops;
@@ -904,34 +904,34 @@ static t_std_error sdi_i2cdev_driver_register(std_config_node_t node,
         error = SDI_DEVICE_ERRNO;
         free(sys_i2c_bus);
         SDI_DEVICE_ERRMSG_LOG("%s:%d i2c bus %u lock init failed %d\n",
-            __FUNCTION__, __LINE__, i2c_bus->bus.bus_id, error);
+                __FUNCTION__, __LINE__, i2c_bus->bus.bus_id, error);
         return error;
     }
 
     str = std_config_attr_get(node, SDI_DEV_ATTR_SYSFS_NAME);
     if (str != NULL) {
         safestrncpy(sys_i2c_bus->kernel_sysfs_name,
-                    str,
-                    sizeof(sys_i2c_bus->kernel_sysfs_name)
-                    );
+                str,
+                sizeof(sys_i2c_bus->kernel_sysfs_name)
+                );
     }
 
     str = std_config_attr_get(node, SDI_DEV_ATTR_DEV_NAME);
     if (str != NULL) {
         /*fill the dev name directly if it is passed*/
         safestrncpy(sys_i2c_bus->kernel_i2cdev_name,
-                    str,
-                    sizeof(sys_i2c_bus->kernel_i2cdev_name)
-                    );
+                str,
+                sizeof(sys_i2c_bus->kernel_i2cdev_name)
+                );
     }
 
     if (sys_i2c_bus->kernel_sysfs_name[0] == 0
-        && sys_i2c_bus->kernel_i2cdev_name[0] == 0
-        ) {
+            && sys_i2c_bus->kernel_i2cdev_name[0] == 0
+       ) {
         error = SDI_DEVICE_ERRNO;
         free(sys_i2c_bus);
         SDI_DEVICE_ERRMSG_LOG("%s:%d i2c bus %u \n No sysfs or dev name given",
-            __FUNCTION__, __LINE__, i2c_bus->bus.bus_id);
+                __FUNCTION__, __LINE__, i2c_bus->bus.bus_id);
         return error;
     }
 

--- a/src/drivers/sys-interface-drivers/sdi_sysfs_gpio_helpers.c
+++ b/src/drivers/sys-interface-drivers/sdi_sysfs_gpio_helpers.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/framework/sdi_bus_api.c
+++ b/src/framework/sdi_bus_api.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/framework/sdi_bus_framework.c
+++ b/src/framework/sdi_bus_framework.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/framework/sdi_driver_framework.c
+++ b/src/framework/sdi_driver_framework.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/framework/sdi_i2c_bus_api.c
+++ b/src/framework/sdi_i2c_bus_api.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/framework/sdi_io_port_api.c
+++ b/src/framework/sdi_io_port_api.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/framework/sdi_pin_bus_api.c
+++ b/src/framework/sdi_pin_bus_api.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/framework/sdi_pin_group_bus_api.c
+++ b/src/framework/sdi_pin_group_bus_api.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/framework/sdi_resource_framework.c
+++ b/src/framework/sdi_resource_framework.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain
@@ -31,6 +31,7 @@
 #include "sdi_entity_info_internal.h"
 #include "std_assert.h"
 #include "std_llist.h"
+#include "std_utils.h"
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
@@ -94,7 +95,7 @@ void sdi_resource_add(sdi_resource_type_t type, const char *name, void *callback
     newnode->resource_hdl = (struct sdi_resource *)calloc(1, sizeof(struct sdi_resource));
     STD_ASSERT(newnode->resource_hdl != NULL);
 
-    strncpy(newnode->resource_hdl->name, name, SDI_MAX_NAME_LEN);
+    safestrncpy(newnode->resource_hdl->name, name, SDI_MAX_NAME_LEN);
     newnode->resource_hdl->type = type;
     newnode->resource_hdl->callback_hdl = callback_hdl;
     newnode->resource_hdl->callback_fns = callback_fns;

--- a/src/framework/sdi_smartfusion_io_bus_api.c
+++ b/src/framework/sdi_smartfusion_io_bus_api.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/hwcore/sdi_comm_dev.c
+++ b/src/hwcore/sdi_comm_dev.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/hwcore/sdi_entity.c
+++ b/src/hwcore/sdi_entity.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain
@@ -89,7 +89,15 @@ t_std_error sdi_entity_presence_get(sdi_entity_hdl_t entity_hdl, bool *presence)
             rc = sdi_bmc_dc_sensor_reading_get_by_name(entity_priv_hdl->pres_attr, &reading);
             if (rc == STD_ERR_OK) {
                 if (entity_priv_hdl->type == SDI_ENTITY_FAN_TRAY) {
-                    *presence = ((reading == SDI_BMC_ENTITY_PRESENT) ? true : false);
+                    if (entity_priv_hdl->pres_bit == SDI_BMC_INVALID_BIT) {
+                        *presence = ((reading == SDI_BMC_ENTITY_PRESENT) ? true : false);
+                    } else {
+                        if (STD_BIT_TEST(reading, entity_priv_hdl->pres_bit)) {
+                            *presence = true;
+                        } else {
+                            *presence = false;
+                        }
+                    }
                 } else if (entity_priv_hdl->type == SDI_ENTITY_PSU_TRAY) {
                     if (STD_BIT_TEST(reading, SDI_BMC_PSU_STATUS_PRSNT)) {
                         *presence = true;

--- a/src/hwcore/sdi_entity_framework.c
+++ b/src/hwcore/sdi_entity_framework.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain
@@ -330,6 +330,7 @@ sdi_entity_hdl_t sdi_entity_create(sdi_entity_type_t type, uint_t instance, cons
     entity_hdl->delay = 0;
     entity_hdl->power_output_status_pin_hdl = NULL;
     entity_hdl->pres_pin_hdl = NULL;
+    entity_hdl->pres_bit = SDI_BMC_INVALID_BIT;
     entity_hdl->fault_status_pin_hdl = NULL;
     entity_hdl->power_pin_hdl = NULL;
     for (reset_type = 0; reset_type < MAX_NUM_RESET; reset_type++) {
@@ -587,7 +588,7 @@ void sdi_register_entity(std_config_node_t node)
     if (alias_name == NULL) {
         snprintf(alias, SDI_MAX_NAME_LEN, "%s-%u",entity_name, instance);
     } else {
-        strncpy(alias, alias_name, SDI_MAX_NAME_LEN);
+        safestrncpy(alias, alias_name, SDI_MAX_NAME_LEN);
     }
 
     config_attr = std_config_attr_get(node, "type");
@@ -622,6 +623,11 @@ void sdi_register_entity(std_config_node_t node)
         /* if presence attribute is a FIXED_SLOT, consider it as FIXED Entity */
         STD_BIT_CLEAR(entity_priv_hdl->oper_support_flag, SDI_HOTSWAPPABLE);
         entity_priv_hdl->pres_pin_hdl = NULL;
+    }
+
+    config_attr = std_config_attr_get(node, "presence_bit");
+    if (config_attr != NULL) {
+        entity_priv_hdl->pres_bit = (uint_t) strtoul(config_attr, NULL, 0x10);
     }
 
     fault_name = std_config_attr_get(node, "fault");

--- a/src/hwcore/sdi_entity_info.c
+++ b/src/hwcore/sdi_entity_info.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/hwcore/sdi_entity_reset.c
+++ b/src/hwcore/sdi_entity_reset.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/hwcore/sdi_fan.c
+++ b/src/hwcore/sdi_fan.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/hwcore/sdi_host_system.c
+++ b/src/hwcore/sdi_host_system.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/hwcore/sdi_led.c
+++ b/src/hwcore/sdi_led.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/hwcore/sdi_media.c
+++ b/src/hwcore/sdi_media.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain
@@ -672,7 +672,7 @@ t_std_error sdi_media_phy_link_status_get (sdi_resource_hdl_t resource_hdl, uint
             channel, type, status);
     if (rc != STD_ERR_OK){
         if( STD_ERR_EXT_PRIV(rc) != EOPNOTSUPP ) {
-            SDI_ERRMSG_LOG("Failed to Set mode for media phy details for %s error code : %d(0x%x)",
+            SDI_ERRMSG_LOG("Failed to get status for media phy for %s error code : %d(0x%x)",
                     media_hdl->name, rc, rc);
         }
     }

--- a/src/hwcore/sdi_nvram.c
+++ b/src/hwcore/sdi_nvram.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/hwcore/sdi_power_monitor.c
+++ b/src/hwcore/sdi_power_monitor.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/hwcore/sdi_startup.c
+++ b/src/hwcore/sdi_startup.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/hwcore/sdi_thermal.c
+++ b/src/hwcore/sdi_thermal.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/hwcore/unittest/sdi_reference.cpp
+++ b/src/hwcore/unittest/sdi_reference.cpp
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/hwcore/unittest/sdi_target.cpp
+++ b/src/hwcore/unittest/sdi_target.cpp
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/hwcore/unittest/sdi_unit_test.cpp
+++ b/src/hwcore/unittest/sdi_unit_test.cpp
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/hwcore/unittest_utils/pysdi.py
+++ b/src/hwcore/unittest_utils/pysdi.py
@@ -1,12 +1,12 @@
 #!/usr/bin/python
 #
-# Copyright (c) 2018 Dell Inc.
+# Copyright (c) 2019 Dell Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain
 # a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 #
-# THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR
+# THIS CODE IS PROVIDED ON AN #AS IS* BASIS, WITHOUT WARRANTIES OR
 # CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
 #  LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
 # FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.

--- a/src/hwcore/unittest_utils/sdi_shell.py
+++ b/src/hwcore/unittest_utils/sdi_shell.py
@@ -1,12 +1,12 @@
 #!/usr/bin/python
 #
-# Copyright (c) 2018 Dell Inc.
+# Copyright (c) 2019 Dell Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain
 # a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 #
-# THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR
+# THIS CODE IS PROVIDED ON AN #AS IS* BASIS, WITHOUT WARRANTIES OR
 # CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
 #  LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
 # FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.

--- a/src/unit_test/run_test
+++ b/src/unit_test/run_test
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2018 Dell Inc.
+# Copyright (c) 2019 Dell Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/src/vmcore/sdi_vm_comm_dev.c
+++ b/src/vmcore/sdi_vm_comm_dev.c
@@ -3,7 +3,7 @@
  *
  * Comm Dev simulation functionality
  *
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain
@@ -18,8 +18,11 @@
  * permissions and limitations under the License.
  */
 
+#include "db_sql_ops.h"
 #include "sdi_comm_dev.h"
+#include "sdi_sys_vm.h"
 #include "std_error_codes.h"
+#include "std_assert.h"
 
 #include <stdint.h>
 
@@ -38,6 +41,15 @@ t_std_error sdi_comm_dev_msg_write(sdi_resource_hdl_t resource_hdl, uint16_t siz
 /* SDI COMM DEV - Read static data from Comm_Dev */
 t_std_error sdi_comm_dev_platform_info_get(sdi_resource_hdl_t resource_hdl, sdi_platform_info_t *platform_info)
 {
+    STD_ASSERT(platform_info != NULL);
+
+    db_sql_handle_t db_hdl = sdi_get_db_handle();
+    sdi_db_str_field_get(db_hdl, resource_hdl, TABLE_COMMDEV, COMMDEV_SERVICE_TAG,
+                                                    platform_info->service_tag);
+    sdi_db_str_field_get(db_hdl, resource_hdl, TABLE_COMMDEV, COMMDEV_FW_VER,
+                                                    platform_info->comm_dev_fw_ver);
+    sdi_db_int_field_get(db_hdl, resource_hdl, TABLE_COMMDEV, COMMDEV_SLOT_ID,
+                                             (int *)&platform_info->slot_occupation);
     return STD_ERR_OK;
 }
 

--- a/src/vmcore/sdi_vm_entity.c
+++ b/src/vmcore/sdi_vm_entity.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/vmcore/sdi_vm_fan.c
+++ b/src/vmcore/sdi_vm_fan.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/vmcore/sdi_vm_host_system.c
+++ b/src/vmcore/sdi_vm_host_system.c
@@ -1,7 +1,7 @@
 /**
  * sdi_vm_host_system.c
  *
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/vmcore/sdi_vm_led.c
+++ b/src/vmcore/sdi_vm_led.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/vmcore/sdi_vm_media.c
+++ b/src/vmcore/sdi_vm_media.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/vmcore/sdi_vm_nvram.c
+++ b/src/vmcore/sdi_vm_nvram.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain
@@ -38,13 +38,11 @@
 static int sdi_nvram_find_or_create_nvram_file(const char *path, uint_t size)
 {
     char nvram_file[NAME_MAX];
-    int access_rc;
     int fd;
 
     sdi_db_construct_path(nvram_file, path);
-    access_rc = access(nvram_file, F_OK);
 
-    if (access_rc == -1) {
+    if (access(nvram_file, F_OK) == -1) {
         if (errno != ENOENT)  return (-1);
 
         fd = open(nvram_file, O_CREAT | O_RDWR, S_IRWXU | S_IRWXG | S_IRWXO);

--- a/src/vmcore/sdi_vm_power_monitor.c
+++ b/src/vmcore/sdi_vm_power_monitor.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/vmcore/sdi_vm_sys.c
+++ b/src/vmcore/sdi_vm_sys.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/vmcore/sdi_vm_thermal.c
+++ b/src/vmcore/sdi_vm_thermal.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/vmcore/unit_test/run_test
+++ b/src/vmcore/unit_test/run_test
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2018 Dell Inc.
+# Copyright (c) 2019 Dell Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/src/vmcore/unit_test/sdi_vm_entity_info_unittest.cpp
+++ b/src/vmcore/unit_test/sdi_vm_entity_info_unittest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain
@@ -54,7 +54,7 @@ TEST(sdi_vm_entity_info_unittest, entityLookup)
 /* FAIL: incase of entity presence */
 TEST(sdi_vm_entity_info_unittest, entityPresenceGet)
 {
-    bool presence;
+    bool presence=false;
     sdi_entity_hdl_t e_hdl;
     ASSERT_EQ (STD_ERR_OK, sdi_sys_init ());
     //setup to make the entity absent

--- a/src/vmcore/unit_test/sdi_vm_fan_unittest.cpp
+++ b/src/vmcore/unit_test/sdi_vm_fan_unittest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/vmcore/unit_test/sdi_vm_led_unittest.cpp
+++ b/src/vmcore/unit_test/sdi_vm_led_unittest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/vmcore/unit_test/sdi_vm_media_unittest.cpp
+++ b/src/vmcore/unit_test/sdi_vm_media_unittest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/vmcore/unit_test/sdi_vm_thermal_unittest.cpp
+++ b/src/vmcore/unit_test/sdi_vm_thermal_unittest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain

--- a/src/vmcore/unit_test/tests/sdi_run_tests.sh
+++ b/src/vmcore/unit_test/tests/sdi_run_tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2018 Dell Inc.
+# Copyright (c) 2019 Dell Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain

--- a/src/vmdb/sdi_db_ops.c
+++ b/src/vmdb/sdi_db_ops.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Dell Inc.
+ * Copyright (c) 2019 Dell Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain
@@ -1311,7 +1311,7 @@ t_std_error sdi_db_bin_field_get(db_sql_handle_t db_handle,
                                  uint8_t *value,
                                  uint_t *len)
 {
-    char sql_stmt[SDI_DB_SQL_DEFAULT_BUFFER_LENGTH];
+    char sql_stmt[SDI_DB_SQL_DEFAULT_BUFFER_LENGTH*2];
     char condition[SDI_DB_SQL_DEFAULT_BUFFER_LENGTH];
     char result[SDI_DB_SQL_DEFAULT_BUFFER_LENGTH];
     size_t length = sizeof(result);
@@ -1851,7 +1851,7 @@ t_std_error sdi_db_media_monitor_threshold_set(db_sql_handle_t db_handle,
                                      channel, type);
     snprintf(value_str, sizeof(value_str), "%u", value);
     return sdi_db_sql_set_attribute(db_handle, TABLE_MEDIA_THRESHOLD,
-                                MEDIA_THRESHOLD_VALUE, condition, value_str);
+                                MEDIA_THRESHOLD_VALUE, value_str, condition);
 }
 
 /**
@@ -1910,7 +1910,7 @@ t_std_error sdi_db_media_threshold_set(db_sql_handle_t db_handle,
                                      MEDIA_DEFAULT_CHANNEL, type);
     snprintf(value_str, sizeof(value_str), "%f", value);
     return sdi_db_sql_set_attribute(db_handle, TABLE_MEDIA_THRESHOLD,
-                                MEDIA_THRESHOLD_VALUE, condition, value_str);
+                                MEDIA_THRESHOLD_VALUE, value_str, condition);
 }
 
 /**

--- a/utils/bin/smfmbox.py
+++ b/utils/bin/smfmbox.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright (c) 2018 Dell Inc.
+# Copyright (c) 2019 Dell Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may
 # not use this file except in compliance with the License. You may obtain


### PR DESCRIPTION
* Bugfix: Adjust the elm_data offset due to the openIPMI data header removal
* Bugfix: Made changes in sdi_bmc_fan_status_get function to return success and
        fault status as good when SDI BMC driver doesnt find fan status sensor in BMC sensor list
* Update: Separate PSU DC type, AC+DC type, so we can debug the BMC spurious data
* Bugfix: Made changes in sdi_bmc_fan_status_get function to return success and
        falut status as good when SDI BMC driver doesnt find fan status sensor in BMC sensor list
* Bugfix: Reset eeprom version on module init
* Bugfix: Address High Sev Coverity issues
* Bugfix: Fixed issue in getting the fan status from discrete state sensor
* Bugfix: Support rate select on 10gbaseT
* Update: Bringing Platform specific changes into device.xml
* Update: Changed BITMASK to BIT
* Bugfix: S5212F built-in FAN and PSU details are not displayed

Signed-off-by: Tejaswi Goel <Tejaswi_Goel@Dell.com>